### PR TITLE
管理権限を持った管理ユーザーしか管理ユーザーを作成できないようにDeviseの設定を変更

### DIFF
--- a/app/controllers/admins/admin_users_controller.rb
+++ b/app/controllers/admins/admin_users_controller.rb
@@ -1,6 +1,12 @@
 class Admins::AdminUsersController < Admins::ApplicationController
   before_action :assign_admin_user, only: [:show, :edit, :update, :destroy]
   before_action :assign_admin_users_index_url, only: [:new, :create, :show, :edit, :update, :destroy]
+
+  def index
+    @q = Admin.ransack(params[:q])
+    @admin_users = @q.result(distinct: true).page(params[:page])
+    session[:admin_users_index_url] = request.url
+  end
   
   def new
     @admin_user = Admin.new

--- a/app/controllers/admins/admin_users_controller.rb
+++ b/app/controllers/admins/admin_users_controller.rb
@@ -1,6 +1,7 @@
 class Admins::AdminUsersController < Admins::ApplicationController
   before_action :assign_admin_user, only: [:show, :edit, :update, :destroy]
   before_action :assign_admin_users_index_url, only: [:new, :create, :show, :edit, :update, :destroy]
+  before_action :authenticate_owner_for_edit_and_destroy!, only: [:edit, :update, :destroy]
 
   def index
     @q = Admin.ransack(params[:q])
@@ -62,5 +63,12 @@ class Admins::AdminUsersController < Admins::ApplicationController
   def assign_admin_users_index_url
     @admin_users_index_url = session[:admin_users_index_url]
   end
+
+  def authenticate_owner_for_edit_and_destroy!
+    unless current_admin && (@admin_user.id != 1 || current_admin.id == 1)
+      flash[:alert] = "オーナー情報を編集する権限がありません。"
+      redirect_to admins_admin_users_path
+    end
+  end  
 end
 

--- a/app/controllers/admins/admin_users_controller.rb
+++ b/app/controllers/admins/admin_users_controller.rb
@@ -1,0 +1,34 @@
+class Admins::AdminUsersController < Admins::ApplicationController
+  before_action :assign_admin_user, only: [:show, :edit, :update, :destroy]
+  before_action :assign_admin_users_index_url, only: [:new, :create, :show, :edit, :update, :destroy]
+
+  def new
+    @admin_user = Admin.new
+  end
+  
+  def create
+    @admin_user = Admin.new(admin_user_params)
+    begin
+      @admin_user.save!
+      redirect_to @admin_users_index_url, notice: "#{@admin_user.name}の登録ができました"
+    rescue
+      flash.now[:alert] = "管理ユーザーの登録ができませんでした"
+      render "new"
+    end
+  end
+  
+  private
+  
+  def admin_user_params
+    params.require(:admin).permit(:name, :email, :role, :password, :password_confirmation)
+  end
+
+  def assign_admin_user
+    @admin_user = Admin.find(params[:id])
+  end
+
+  def assign_admin_users_index_url
+    @admin_users_index_url = session[:admin_users_index_url]
+  end
+end
+

--- a/app/controllers/admins/admin_users_controller.rb
+++ b/app/controllers/admins/admin_users_controller.rb
@@ -36,6 +36,7 @@ class Admins::AdminUsersController < Admins::ApplicationController
     authenticate_role!
     @admin_users_index_url = session[:admin_users_index_url]
     @admin_user = Admin.find(params[:id])
+    @fixed_role_owner_options = fixed_role_owner_options
     editable_owner_admin_user!
   end
   
@@ -43,6 +44,7 @@ class Admins::AdminUsersController < Admins::ApplicationController
     authenticate_role!
     @admin_users_index_url = session[:admin_users_index_url]
     @admin_user = Admin.find(params[:id])
+    @fixed_role_owner_options = fixed_role_owner_options
     editable_owner_admin_user!
     begin
       @admin_user.update!(admin_user_params)
@@ -72,6 +74,12 @@ class Admins::AdminUsersController < Admins::ApplicationController
   def admin_user_params
     params.require(:admin).permit(:name, :email, :role, :password, :password_confirmation)
   end
+
+  def fixed_role_owner_options
+    [['オーナー', 'owner']]
+  end
+
+  
 
   def editable_owner_admin_user!
     return if current_admin.role.owner?

--- a/app/controllers/admins/admin_users_controller.rb
+++ b/app/controllers/admins/admin_users_controller.rb
@@ -34,16 +34,16 @@ class Admins::AdminUsersController < Admins::ApplicationController
   
   def edit
     authenticate_role!
-    editable_owner_admin_user!
     @admin_users_index_url = session[:admin_users_index_url]
     @admin_user = Admin.find(params[:id])
+    editable_owner_admin_user!
   end
   
   def update
     authenticate_role!
-    editable_owner_admin_user!
     @admin_users_index_url = session[:admin_users_index_url]
     @admin_user = Admin.find(params[:id])
+    editable_owner_admin_user!
     begin
       @admin_user.update!(admin_user_params)
       redirect_to @admin_users_index_url, notice: "#{@admin_user.name}の内容を変更できました"
@@ -55,9 +55,9 @@ class Admins::AdminUsersController < Admins::ApplicationController
 
   def destroy
     authenticate_role!
-    editable_owner_admin_user!
     @admin_users_index_url = session[:admin_users_index_url]
     @admin_user = Admin.find(params[:id])
+    editable_owner_admin_user!
     begin
       @admin_user.destroy!
       redirect_to @admin_users_index_url|| admins_admin_users_path, notice: "#{@admin_user.name}を削除しました"

--- a/app/controllers/admins/admin_users_controller.rb
+++ b/app/controllers/admins/admin_users_controller.rb
@@ -1,6 +1,4 @@
 class Admins::AdminUsersController < Admins::ApplicationController
-  before_action :assign_admin_user, only: [:show, :edit, :update, :destroy]
-  before_action :assign_admin_users_index_url, only: [:new, :create, :show, :edit, :update, :destroy]
 
   def index
     authenticate_role!
@@ -11,11 +9,13 @@ class Admins::AdminUsersController < Admins::ApplicationController
   
   def new
     authenticate_role!
+    @admin_users_index_url = session[:admin_users_index_url]
     @admin_user = Admin.new
   end
   
   def create
     authenticate_role!
+    @admin_users_index_url = session[:admin_users_index_url]
     @admin_user = Admin.new(admin_user_params)
     begin
       @admin_user.save!
@@ -28,16 +28,22 @@ class Admins::AdminUsersController < Admins::ApplicationController
 
   def show
     authenticate_role!
+    @admin_users_index_url = session[:admin_users_index_url]
+    @admin_user = Admin.find(params[:id])
   end
   
   def edit
     authenticate_role!
     editable_owner_admin_user!
+    @admin_users_index_url = session[:admin_users_index_url]
+    @admin_user = Admin.find(params[:id])
   end
   
   def update
     authenticate_role!
     editable_owner_admin_user!
+    @admin_users_index_url = session[:admin_users_index_url]
+    @admin_user = Admin.find(params[:id])
     begin
       @admin_user.update!(admin_user_params)
       redirect_to @admin_users_index_url, notice: "#{@admin_user.name}の内容を変更できました"
@@ -50,6 +56,8 @@ class Admins::AdminUsersController < Admins::ApplicationController
   def destroy
     authenticate_role!
     editable_owner_admin_user!
+    @admin_users_index_url = session[:admin_users_index_url]
+    @admin_user = Admin.find(params[:id])
     begin
       @admin_user.destroy!
       redirect_to @admin_users_index_url|| admins_admin_users_path, notice: "#{@admin_user.name}を削除しました"
@@ -63,14 +71,6 @@ class Admins::AdminUsersController < Admins::ApplicationController
   
   def admin_user_params
     params.require(:admin).permit(:name, :email, :role, :password, :password_confirmation)
-  end
-
-  def assign_admin_user
-    @admin_user = Admin.find(params[:id])
-  end
-
-  def assign_admin_users_index_url
-    @admin_users_index_url = session[:admin_users_index_url]
   end
 
   def editable_owner_admin_user!

--- a/app/controllers/admins/admin_users_controller.rb
+++ b/app/controllers/admins/admin_users_controller.rb
@@ -66,7 +66,7 @@ class Admins::AdminUsersController < Admins::ApplicationController
   end
 
   def authenticate_owner!
-    if @admin_user.id == 1 && current_admin.id != 1
+    if @admin_user.role == :owner && current_admin.role != :owner
       flash[:alert] = "オーナー情報を編集する権限がありません。"
       redirect_to admins_admin_users_path
     end

--- a/app/controllers/admins/admin_users_controller.rb
+++ b/app/controllers/admins/admin_users_controller.rb
@@ -100,4 +100,3 @@ class Admins::AdminUsersController < Admins::ApplicationController
     end
   end
 end
-

--- a/app/controllers/admins/admin_users_controller.rb
+++ b/app/controllers/admins/admin_users_controller.rb
@@ -17,6 +17,9 @@ class Admins::AdminUsersController < Admins::ApplicationController
     end
   end
 
+  def show
+  end
+  
   def edit
   end
   

--- a/app/controllers/admins/admin_users_controller.rb
+++ b/app/controllers/admins/admin_users_controller.rb
@@ -1,7 +1,7 @@
 class Admins::AdminUsersController < Admins::ApplicationController
   before_action :assign_admin_user, only: [:show, :edit, :update, :destroy]
   before_action :assign_admin_users_index_url, only: [:new, :create, :show, :edit, :update, :destroy]
-
+  
   def new
     @admin_user = Admin.new
   end
@@ -14,6 +14,19 @@ class Admins::AdminUsersController < Admins::ApplicationController
     rescue
       flash.now[:alert] = "管理ユーザーの登録ができませんでした"
       render "new"
+    end
+  end
+
+  def edit
+  end
+  
+  def update
+    begin
+      @admin_user.update!(admin_user_params)
+      redirect_to @admin_users_index_url, notice: "#{@admin_user.name}の内容を変更できました"
+    rescue
+      flash.now[:alert] = "#{@admin_user.name}の内容を変更できませんでした"
+      render 'edit'
     end
   end
   

--- a/app/controllers/admins/admin_users_controller.rb
+++ b/app/controllers/admins/admin_users_controller.rb
@@ -1,6 +1,7 @@
 class Admins::AdminUsersController < Admins::ApplicationController
   before_action :assign_admin_user, only: [:show, :edit, :update, :destroy]
   before_action :assign_admin_users_index_url, only: [:new, :create, :show, :edit, :update, :destroy]
+  before_action :authenticate_role!
   before_action :authenticate_owner_for_edit_and_destroy!, only: [:edit, :update, :destroy]
 
   def index
@@ -69,6 +70,13 @@ class Admins::AdminUsersController < Admins::ApplicationController
       flash[:alert] = "オーナー情報を編集する権限がありません。"
       redirect_to admins_admin_users_path
     end
-  end  
+  end
+
+  def authenticate_role!
+    if current_admin.member?
+      flash[:alert] = "管理者権限がありません。"
+      redirect_to admins_root_path
+    end
+  end
 end
 

--- a/app/controllers/admins/admin_users_controller.rb
+++ b/app/controllers/admins/admin_users_controller.rb
@@ -1,20 +1,21 @@
 class Admins::AdminUsersController < Admins::ApplicationController
   before_action :assign_admin_user, only: [:show, :edit, :update, :destroy]
   before_action :assign_admin_users_index_url, only: [:new, :create, :show, :edit, :update, :destroy]
-  before_action :authenticate_role!
-  before_action :authenticate_owner!, only: [:show, :edit, :update, :destroy]
 
   def index
+    authenticate_role!
     @q = Admin.ransack(params[:q])
     @admin_users = @q.result(distinct: true).page(params[:page])
     session[:admin_users_index_url] = request.url
   end
   
   def new
+    authenticate_role!
     @admin_user = Admin.new
   end
   
   def create
+    authenticate_role!
     @admin_user = Admin.new(admin_user_params)
     begin
       @admin_user.save!
@@ -26,12 +27,17 @@ class Admins::AdminUsersController < Admins::ApplicationController
   end
 
   def show
+    authenticate_role!
   end
   
   def edit
+    authenticate_role!
+    editable_owner_admin_user!
   end
   
   def update
+    authenticate_role!
+    editable_owner_admin_user!
     begin
       @admin_user.update!(admin_user_params)
       redirect_to @admin_users_index_url, notice: "#{@admin_user.name}の内容を変更できました"
@@ -42,6 +48,8 @@ class Admins::AdminUsersController < Admins::ApplicationController
   end
 
   def destroy
+    authenticate_role!
+    editable_owner_admin_user!
     begin
       @admin_user.destroy!
       redirect_to @admin_users_index_url|| admins_admin_users_path, notice: "#{@admin_user.name}を削除しました"
@@ -65,11 +73,11 @@ class Admins::AdminUsersController < Admins::ApplicationController
     @admin_users_index_url = session[:admin_users_index_url]
   end
 
-  def authenticate_owner!
-    if @admin_user.role == :owner && current_admin.role != :owner
-      flash[:alert] = "オーナー情報を編集する権限がありません。"
-      redirect_to admins_admin_users_path
-    end
+  def editable_owner_admin_user!
+    return if current_admin.role.owner?
+    return unless @admin_user.role.owner?
+    flash[:alert] = "オーナー情報を編集する権限がありません。"
+     redirect_to admins_admin_users_path
   end
 
   def authenticate_role!

--- a/app/controllers/admins/admin_users_controller.rb
+++ b/app/controllers/admins/admin_users_controller.rb
@@ -29,6 +29,16 @@ class Admins::AdminUsersController < Admins::ApplicationController
       render 'edit'
     end
   end
+
+  def destroy
+    begin
+      @admin_user.destroy!
+      redirect_to @admin_users_index_url|| admins_admin_users_path, notice: "#{@admin_user.name}を削除しました"
+    rescue
+      flash.now[:alert] = "#{@admin_user.name}を削除できませんでした"
+      render 'index'
+    end
+  end
   
   private
   

--- a/app/controllers/admins/admin_users_controller.rb
+++ b/app/controllers/admins/admin_users_controller.rb
@@ -19,7 +19,7 @@ class Admins::AdminUsersController < Admins::ApplicationController
     @new_role_options = new_role_options
     begin
       @admin_user.save!
-      redirect_to @admin_users_index_url, notice: "#{@admin_user.name}の登録ができました"
+      redirect_to index_path_for_redirect, notice: "#{@admin_user.name}の登録ができました"
     rescue
       flash.now[:alert] = "管理ユーザーの登録ができませんでした"
       render "new"
@@ -45,7 +45,7 @@ class Admins::AdminUsersController < Admins::ApplicationController
     editable_owner_admin_user!
     begin
       @admin_user.update!(admin_user_params)
-      redirect_to @admin_users_index_url, notice: "#{@admin_user.name}の内容を変更できました"
+      redirect_to index_path_for_redirect, notice: "#{@admin_user.name}の内容を変更できました"
     rescue
       flash.now[:alert] = "#{@admin_user.name}の内容を変更できませんでした"
       render 'edit'
@@ -53,12 +53,11 @@ class Admins::AdminUsersController < Admins::ApplicationController
   end
 
   def destroy
-    @admin_users_index_url = session[:admin_users_index_url]
     @admin_user = Admin.find(params[:id])
     editable_owner_admin_user!
     begin
       @admin_user.destroy!
-      redirect_to @admin_users_index_url|| admins_admin_users_path, notice: "#{@admin_user.name}を削除しました"
+      redirect_to index_path_for_redirect, notice: "#{@admin_user.name}を削除しました"
     rescue
       flash.now[:alert] = "#{@admin_user.name}を削除できませんでした"
       render 'index'
@@ -82,8 +81,10 @@ class Admins::AdminUsersController < Admins::ApplicationController
       Admin.role.options.reject { |_, value| value == 'owner' }
     end
   end
-  
 
+  def index_path_for_redirect
+    session[:admin_users_index_url] || admins_admin_users_path
+  end
   
   def editable_owner_admin_user!
     return if current_admin.role.owner?

--- a/app/controllers/admins/admin_users_controller.rb
+++ b/app/controllers/admins/admin_users_controller.rb
@@ -1,20 +1,18 @@
 class Admins::AdminUsersController < Admins::ApplicationController
+  before_action :authenticate_role!
 
   def index
-    authenticate_role!
     @q = Admin.ransack(params[:q])
     @admin_users = @q.result(distinct: true).page(params[:page])
     session[:admin_users_index_url] = request.url
   end
   
   def new
-    authenticate_role!
     @admin_users_index_url = session[:admin_users_index_url]
     @admin_user = Admin.new
   end
   
   def create
-    authenticate_role!
     @admin_users_index_url = session[:admin_users_index_url]
     @admin_user = Admin.new(admin_user_params)
     begin
@@ -27,13 +25,12 @@ class Admins::AdminUsersController < Admins::ApplicationController
   end
 
   def show
-    authenticate_role!
     @admin_users_index_url = session[:admin_users_index_url]
     @admin_user = Admin.find(params[:id])
   end
   
   def edit
-    authenticate_role!
+    
     @admin_users_index_url = session[:admin_users_index_url]
     @admin_user = Admin.find(params[:id])
     @fixed_role_owner_options = fixed_role_owner_options
@@ -41,7 +38,6 @@ class Admins::AdminUsersController < Admins::ApplicationController
   end
   
   def update
-    authenticate_role!
     @admin_users_index_url = session[:admin_users_index_url]
     @admin_user = Admin.find(params[:id])
     @fixed_role_owner_options = fixed_role_owner_options
@@ -56,7 +52,6 @@ class Admins::AdminUsersController < Admins::ApplicationController
   end
 
   def destroy
-    authenticate_role!
     @admin_users_index_url = session[:admin_users_index_url]
     @admin_user = Admin.find(params[:id])
     editable_owner_admin_user!

--- a/app/controllers/admins/admin_users_controller.rb
+++ b/app/controllers/admins/admin_users_controller.rb
@@ -10,11 +10,13 @@ class Admins::AdminUsersController < Admins::ApplicationController
   def new
     @admin_users_index_url = session[:admin_users_index_url]
     @admin_user = Admin.new
+    @new_role_options = new_role_options
   end
   
   def create
     @admin_users_index_url = session[:admin_users_index_url]
     @admin_user = Admin.new(admin_user_params)
+    @new_role_options = new_role_options
     begin
       @admin_user.save!
       redirect_to @admin_users_index_url, notice: "#{@admin_user.name}の登録ができました"
@@ -30,17 +32,16 @@ class Admins::AdminUsersController < Admins::ApplicationController
   end
   
   def edit
-    
     @admin_users_index_url = session[:admin_users_index_url]
     @admin_user = Admin.find(params[:id])
-    @fixed_role_owner_options = fixed_role_owner_options
+    @edit_role_options = edit_role_options
     editable_owner_admin_user!
   end
   
   def update
     @admin_users_index_url = session[:admin_users_index_url]
     @admin_user = Admin.find(params[:id])
-    @fixed_role_owner_options = fixed_role_owner_options
+    @edit_role_options = edit_role_options
     editable_owner_admin_user!
     begin
       @admin_user.update!(admin_user_params)
@@ -70,12 +71,20 @@ class Admins::AdminUsersController < Admins::ApplicationController
     params.require(:admin).permit(:name, :email, :role, :password, :password_confirmation)
   end
 
-  def fixed_role_owner_options
-    [['オーナー', 'owner']]
+  def new_role_options
+    Admin.role.options.reject { |_, value| value == 'owner' }
   end
 
+  def edit_role_options
+    if @admin_user.role.owner?
+      [['オーナー', 'owner']]
+    else
+      Admin.role.options.reject { |_, value| value == 'owner' }
+    end
+  end
   
 
+  
   def editable_owner_admin_user!
     return if current_admin.role.owner?
     return unless @admin_user.role.owner?

--- a/app/controllers/admins/admin_users_controller.rb
+++ b/app/controllers/admins/admin_users_controller.rb
@@ -2,7 +2,7 @@ class Admins::AdminUsersController < Admins::ApplicationController
   before_action :assign_admin_user, only: [:show, :edit, :update, :destroy]
   before_action :assign_admin_users_index_url, only: [:new, :create, :show, :edit, :update, :destroy]
   before_action :authenticate_role!
-  before_action :authenticate_owner_for_edit_and_destroy!, only: [:edit, :update, :destroy]
+  before_action :authenticate_owner!, only: [:show, :edit, :update, :destroy]
 
   def index
     @q = Admin.ransack(params[:q])
@@ -65,8 +65,8 @@ class Admins::AdminUsersController < Admins::ApplicationController
     @admin_users_index_url = session[:admin_users_index_url]
   end
 
-  def authenticate_owner_for_edit_and_destroy!
-    unless current_admin && (@admin_user.id != 1 || current_admin.id == 1)
+  def authenticate_owner!
+    if @admin_user.id == 1 && current_admin.id != 1
       flash[:alert] = "オーナー情報を編集する権限がありません。"
       redirect_to admins_admin_users_path
     end

--- a/app/controllers/admins/articles_controller.rb
+++ b/app/controllers/admins/articles_controller.rb
@@ -21,7 +21,7 @@ class Admins::ArticlesController < Admins::ApplicationController
     @article = Article.new(article_params)
     begin
       @article.save!
-      redirect_to @articles_index_url, notice: "ブログの登録ができました"
+      redirect_to index_path_for_redirect, notice: "ブログの登録ができました"
     rescue
       flash.now[:alert] = "ブログの登録ができませんでした"
       render "new"
@@ -48,7 +48,7 @@ class Admins::ArticlesController < Admins::ApplicationController
     @article = Article.find(params[:id])
     begin
       @article.update!(article_params)
-      redirect_to @articles_index_url, notice: "ブログの内容を変更できました"
+      redirect_to index_path_for_redirect, notice: "ブログの内容を変更できました"
     rescue
       flash.now[:alert] = "ブログの内容を変更できませんでした"
       render 'edit'
@@ -56,11 +56,10 @@ class Admins::ArticlesController < Admins::ApplicationController
   end
 
   def destroy
-    @articles_index_url = session[:articles_index_url]
     @article = Article.find(params[:id])
     begin
       @article.destroy!
-      redirect_to @articles_index_url|| admins_articles_path, notice: "ブログを削除しました"
+      redirect_to index_path_for_redirect, notice: "ブログを削除しました"
     rescue
       flash.now[:alert] = "ブログを削除できませんでした"
       render 'index'
@@ -79,5 +78,9 @@ class Admins::ArticlesController < Admins::ApplicationController
 
   def end_at_options
     { min: (Time.zone.now + 1.day).strftime("%Y-%m-%dT%H:%M"), value: (Time.zone.now + 1.day).strftime("%Y-%m-%dT%H:%M") }
+  end
+
+  def index_path_for_redirect
+    session[:articles_index_url] || admins_articles_path
   end
 end

--- a/app/controllers/admins/articles_controller.rb
+++ b/app/controllers/admins/articles_controller.rb
@@ -1,7 +1,4 @@
 class Admins::ArticlesController < Admins::ApplicationController
-  before_action :assign_article, only: [:show, :edit, :update, :destroy]
-  before_action :assign_articles_index_url, only: [:new, :create, :show, :edit, :update, :destroy]
-  before_action :assign_article_time_options, only: [:new, :create, :edit, :update]
 
   def index
     @q = Article.ransack(params[:q])
@@ -10,11 +7,17 @@ class Admins::ArticlesController < Admins::ApplicationController
   end
 
   def new
+    @articles_index_url = session[:articles_index_url]
+    @start_at_options = start_at_options
+    @end_at_options = end_at_options
     @article = Article.new
     @article.contents.build
   end
   
   def create
+    @articles_index_url = session[:articles_index_url]
+    @start_at_options = start_at_options
+    @end_at_options = end_at_options
     @article = Article.new(article_params)
     begin
       @article.save!
@@ -26,13 +29,23 @@ class Admins::ArticlesController < Admins::ApplicationController
   end
 
   def show
+    @articles_index_url = session[:articles_index_url]
+    @article = Article.find(params[:id])
   end
   
 
   def edit
+    @articles_index_url = session[:articles_index_url]
+    @start_at_options = start_at_options
+    @end_at_options = end_at_options
+    @article = Article.find(params[:id])
   end
   
   def update
+    @articles_index_url = session[:articles_index_url]
+    @start_at_options = start_at_options
+    @end_at_options = end_at_options
+    @article = Article.find(params[:id])
     begin
       @article.update!(article_params)
       redirect_to @articles_index_url, notice: "ブログの内容を変更できました"
@@ -43,6 +56,8 @@ class Admins::ArticlesController < Admins::ApplicationController
   end
 
   def destroy
+    @articles_index_url = session[:articles_index_url]
+    @article = Article.find(params[:id])
     begin
       @article.destroy!
       redirect_to @articles_index_url|| admins_articles_path, notice: "ブログを削除しました"
@@ -53,19 +68,6 @@ class Admins::ArticlesController < Admins::ApplicationController
   end
   
   private
-
-  def assign_article
-    @article = Article.find(params[:id])
-  end
-
-  def assign_articles_index_url
-    @articles_index_url = session[:articles_index_url]
-  end
-
-  def assign_article_time_options
-    @start_at_options = start_at_options
-    @end_at_options = end_at_options
-  end
   
   def article_params
     params.require(:article).permit(:title, :start_at, :end_at, :category, contents_attributes: [:id, :body, :article_image,:article_image_cache, :_destroy])

--- a/app/controllers/admins/news_controller.rb
+++ b/app/controllers/admins/news_controller.rb
@@ -23,7 +23,7 @@ class Admins::NewsController < Admins::ApplicationController
     @news = News.new(news_params)
     begin
       @news.save!
-      redirect_to @news_index_url, notice: "お知らせの投稿ができました"
+      redirect_to index_path_for_redirect, notice: "お知らせの投稿ができました"
     rescue
       flash.now[:alert] = "お知らせの投稿ができませんでした"
       render "new"
@@ -51,7 +51,7 @@ class Admins::NewsController < Admins::ApplicationController
     @news = News.find(params[:id])
     begin
       @news.update!(news_params)
-      redirect_to @news_index_url, notice: "お知らせの内容を変更できました"
+      redirect_to index_path_for_redirect, notice: "お知らせの内容を変更できました"
     rescue
       flash.now[:alert] = "お知らせの内容を変更できませんでした"
       render 'edit'
@@ -59,11 +59,10 @@ class Admins::NewsController < Admins::ApplicationController
   end
   
   def destroy
-    @news_index_url = session[:news_index_url]
     @news = News.find(params[:id])
     begin
       @news.destroy!
-      redirect_to @news_index_url|| admins_news_index_path, notice: "お知らせを削除しました"
+      redirect_to index_path_for_redirect, notice: "お知らせを削除しました"
     rescue
       flash.now[:alert] = "お知らせを削除できませんでした"
       render 'index'
@@ -87,5 +86,9 @@ class Admins::NewsController < Admins::ApplicationController
 
   def end_at_options
     { min: (Time.zone.now + 1.day).strftime("%Y-%m-%dT%H:%M"), value: (Time.zone.now + 1.day).strftime("%Y-%m-%dT%H:%M") }
+  end
+
+  def index_path_for_redirect
+    session[:news_index_url] || admins_news_index_path
   end
 end

--- a/app/controllers/admins/news_controller.rb
+++ b/app/controllers/admins/news_controller.rb
@@ -1,7 +1,4 @@
 class Admins::NewsController < Admins::ApplicationController
-  before_action :assign_news, only: [:show, :edit, :update, :destroy]
-  before_action :assign_news_index_url, only: [:new, :create, :show, :edit, :update, :destroy]
-  before_action :assign_news_time_options, only: [:new, :create, :edit, :update]
  
   def index
     @q = News.ransack(params[:q])
@@ -11,10 +8,18 @@ class Admins::NewsController < Admins::ApplicationController
   end
 
   def new
+    @news_index_url = session[:news_index_url]
+    @calendar_date_options = calendar_date_options
+    @start_at_options = start_at_options
+    @end_at_options = end_at_options
     @news = News.new
   end
   
   def create
+    @news_index_url = session[:news_index_url]
+    @calendar_date_options = calendar_date_options
+    @start_at_options = start_at_options
+    @end_at_options = end_at_options
     @news = News.new(news_params)
     begin
       @news.save!
@@ -26,12 +31,24 @@ class Admins::NewsController < Admins::ApplicationController
   end
   
   def show
+    @news_index_url = session[:news_index_url]
+    @news = News.find(params[:id])
   end
 
   def edit
+    @news_index_url = session[:news_index_url]
+    @calendar_date_options = calendar_date_options
+    @start_at_options = start_at_options
+    @end_at_options = end_at_options
+    @news = News.find(params[:id])
   end
   
   def update
+    @news_index_url = session[:news_index_url]
+    @calendar_date_options = calendar_date_options
+    @start_at_options = start_at_options
+    @end_at_options = end_at_options
+    @news = News.find(params[:id])
     begin
       @news.update!(news_params)
       redirect_to @news_index_url, notice: "お知らせの内容を変更できました"
@@ -42,6 +59,8 @@ class Admins::NewsController < Admins::ApplicationController
   end
   
   def destroy
+    @news_index_url = session[:news_index_url]
+    @news = News.find(params[:id])
     begin
       @news.destroy!
       redirect_to @news_index_url|| admins_news_index_path, notice: "お知らせを削除しました"
@@ -53,19 +72,6 @@ class Admins::NewsController < Admins::ApplicationController
   
 
   private
-  def assign_news
-    @news = News.find(params[:id])
-  end
-
-  def assign_news_index_url
-    @news_index_url = session[:news_index_url]
-  end
-
-  def assign_news_time_options
-    @calendar_date_options = calendar_date_options
-    @start_at_options = start_at_options
-    @end_at_options = end_at_options
-  end
 
   def news_params
     params.require(:news).permit(:calendar_date, :title, :start_at, :end_at, :body)

--- a/app/controllers/admins/news_controller.rb
+++ b/app/controllers/admins/news_controller.rb
@@ -12,16 +12,10 @@ class Admins::NewsController < Admins::ApplicationController
 
   def new
     @news = News.new
-    @calendar_date_options = calendar_date_options
-    @start_at_options = start_at_options
-    @end_at_options = end_at_options
   end
   
   def create
     @news = News.new(news_params)
-    @calendar_date_options = calendar_date_options
-    @start_at_options = start_at_options
-    @end_at_options = end_at_options
     begin
       @news.save!
       redirect_to @news_index_url, notice: "お知らせの投稿ができました"
@@ -35,15 +29,9 @@ class Admins::NewsController < Admins::ApplicationController
   end
 
   def edit
-    @calendar_date_options = calendar_date_options
-    @start_at_options = start_at_options
-    @end_at_options = end_at_options
   end
   
   def update
-    @calendar_date_options = calendar_date_options
-    @start_at_options = start_at_options
-    @end_at_options = end_at_options
     begin
       @news.update!(news_params)
       redirect_to @news_index_url, notice: "お知らせの内容を変更できました"

--- a/app/controllers/admins/shops_controller.rb
+++ b/app/controllers/admins/shops_controller.rb
@@ -1,7 +1,4 @@
 class Admins::ShopsController < Admins::ApplicationController
-  before_action :assign_shops_index_url, only: [:discarded, :new, :create, :show, :edit, :update, :destroy, :restore]
-  before_action :assign_shops_discarded_url, only: [:show]
-  before_action :assign_shop, only: [:show, :edit, :update, :destroy, :restore]
 
   def index
     @q = Shop.kept.ransack(params[:q])
@@ -11,6 +8,7 @@ class Admins::ShopsController < Admins::ApplicationController
   end
 
   def discarded
+    @shops_index_url = session[:shops_index_url]
     @q = Shop.discarded.ransack(params[:q])
     @discarded_shops = @q.result(distinct: true).page(params[:page])
     @search_residence_scope = :prefecture_name_or_city_name_or_address_cont
@@ -19,11 +17,13 @@ class Admins::ShopsController < Admins::ApplicationController
   end
 
   def new
+    @shops_index_url = session[:shops_index_url]
     @shop = Shop.new
     @prefectures = Prefecture.all
   end
   
   def create
+    @shops_index_url = session[:shops_index_url]
     @shop = Shop.new(shop_params)
     @prefectures = Prefecture.all
     begin
@@ -36,15 +36,21 @@ class Admins::ShopsController < Admins::ApplicationController
   end
   
   def show
+    @shops_index_url = session[:shops_index_url]
     @shops_discarded_url = session[:shops_discarded_url]
+    @shop = Shop.find(params[:id])
     @is_discarded = params[:is_discarded].present?
   end
 
   def edit
+    @shops_index_url = session[:shops_index_url]
+    @shop = Shop.find(params[:id])
     @prefectures = Prefecture.all
   end
   
   def update
+    @shops_index_url = session[:shops_index_url]
+    @shop = Shop.find(params[:id])
     @prefectures = Prefecture.all
     begin
       @shop.update!(shop_params)
@@ -56,6 +62,8 @@ class Admins::ShopsController < Admins::ApplicationController
   end
   
   def destroy
+    @shops_index_url = session[:shops_index_url]
+    @shop = Shop.find(params[:id])
     begin
       @shop.discard!
       redirect_to @shops_index_url|| admins_shops_path, notice: "#{@shop.name}を削除しました"
@@ -66,6 +74,8 @@ class Admins::ShopsController < Admins::ApplicationController
   end
 
   def restore
+    @shops_index_url = session[:shops_index_url]
+    @shop = Shop.find(params[:id])
     begin
       @shop.undiscard!
       redirect_to @shops_index_url, notice: "#{@shop.name}を復元ました"
@@ -82,15 +92,4 @@ class Admins::ShopsController < Admins::ApplicationController
     params.require(:shop).permit(:name, :address, :access, :business_time, :phone_number, :counter_seat, :table_seat, :site_name, :gourmet_site_link, :city_name, :shop_image,:shop_image_cache, :prefecture_id)
   end
   
-  def assign_shop
-    @shop = Shop.find(params[:id])
-  end
-
-  def assign_shops_index_url
-    @shops_index_url = session[:shops_index_url]
-  end
-  
-  def assign_shops_discarded_url
-    @shops_discarded_url = session[:shops_discarded_url]
-  end
 end

--- a/app/controllers/admins/shops_controller.rb
+++ b/app/controllers/admins/shops_controller.rb
@@ -28,7 +28,7 @@ class Admins::ShopsController < Admins::ApplicationController
     @prefectures = Prefecture.all
     begin
       @shop.save!
-      redirect_to @shops_index_url, notice: "#{@shop.name}の登録ができました"
+      redirect_to index_path_for_redirect, notice: "#{@shop.name}の登録ができました"
     rescue
       flash.now[:alert] = "店舗の登録ができませんでした"
       render "new"
@@ -54,7 +54,7 @@ class Admins::ShopsController < Admins::ApplicationController
     @prefectures = Prefecture.all
     begin
       @shop.update!(shop_params)
-      redirect_to @shops_index_url, notice: "#{@shop.name}の内容を変更できました"
+      redirect_to index_path_for_redirect, notice: "#{@shop.name}の内容を変更できました"
     rescue
       flash.now[:alert] = "#{@shop.name}の内容を変更できませんでした"
       render 'edit'
@@ -62,11 +62,10 @@ class Admins::ShopsController < Admins::ApplicationController
   end
   
   def destroy
-    @shops_index_url = session[:shops_index_url]
     @shop = Shop.find(params[:id])
     begin
       @shop.discard!
-      redirect_to @shops_index_url|| admins_shops_path, notice: "#{@shop.name}を削除しました"
+      redirect_to index_path_for_redirect, notice: "#{@shop.name}を削除しました"
     rescue
       flash.now[:alert] = "#{@shop.name}を削除できませんでした"
       render 'index'
@@ -74,11 +73,10 @@ class Admins::ShopsController < Admins::ApplicationController
   end
 
   def restore
-    @shops_index_url = session[:shops_index_url]
     @shop = Shop.find(params[:id])
     begin
       @shop.undiscard!
-      redirect_to @shops_index_url, notice: "#{@shop.name}を復元ました"
+      redirect_to index_path_for_redirect, notice: "#{@shop.name}を復元ました"
     rescue
       flash.now[:alert] = "#{@shop.name}を復元できませんでした"
       render 'discarded'
@@ -90,6 +88,10 @@ class Admins::ShopsController < Admins::ApplicationController
   
   def shop_params
     params.require(:shop).permit(:name, :address, :access, :business_time, :phone_number, :counter_seat, :table_seat, :site_name, :gourmet_site_link, :city_name, :shop_image,:shop_image_cache, :prefecture_id)
+  end
+
+  def index_path_for_redirect
+    session[:shops_index_url] = request.url || admins_shops_path
   end
   
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -3,8 +3,8 @@ class ApplicationController < ActionController::Base
 
   protected
   def configure_permitted_parameters
-    devise_parameter_sanitizer.permit(:sign_up, keys: [:name, :email, :password])
-    devise_parameter_sanitizer.permit(:account_update, keys: [:name])
+    devise_parameter_sanitizer.permit(:sign_up, keys: [:name,:role, :email, :password])
+    devise_parameter_sanitizer.permit(:account_update, keys: [:name, :role])
   end
 
   def after_sign_in_path_for(resource)

--- a/app/frontend/entrypoints/Application.tsx
+++ b/app/frontend/entrypoints/Application.tsx
@@ -24,8 +24,7 @@ const App: React.FC = (props: any) => {
     <Header
       adminsRootPath="/admins"
       destroyAdminSessionPath="/admins/sign_out"
-      currentAdminName={props.currentAdminName}
-      currentAdminRole={props.currentAdminRole}
+      currentAdmin={props.currentAdmin}
       toggleSidebar={toggleSidebar}
     ></Header>
     <div className="container-fluid mobile-gutter">

--- a/app/frontend/entrypoints/Application.tsx
+++ b/app/frontend/entrypoints/Application.tsx
@@ -39,6 +39,8 @@ const App: React.FC = (props: any) => {
          adminsShopsPath="/admins/shops"
          discardedAdminsShopsPath="/admins/shops/discarded"
          newAdminsShopsPath="/admins/shops/new"
+         newAdminsAdminUsersPath="/admins/admin_users/new"
+         adminsAdminUsersPath="/admins/admin_users"
          ></Sidebar>
         <main className={`${isSidebarOpen ? 'ml-sm-auto col-lg-10 col-md-9' : ''}  px-md-4 py-md-4 main-top`}>
           {props.children}

--- a/app/frontend/entrypoints/Application.tsx
+++ b/app/frontend/entrypoints/Application.tsx
@@ -23,8 +23,9 @@ const App: React.FC = (props: any) => {
   return <>
     <Header
       adminsRootPath="/admins"
-      editAdminRegistrationPath="/admins/edit"
       destroyAdminSessionPath="/admins/sign_out"
+      currentAdminName={props.currentAdminName}
+      currentAdminRole={props.currentAdminRole}
       toggleSidebar={toggleSidebar}
     ></Header>
     <div className="container-fluid mobile-gutter">

--- a/app/frontend/entrypoints/Application.tsx
+++ b/app/frontend/entrypoints/Application.tsx
@@ -31,16 +31,17 @@ const App: React.FC = (props: any) => {
     <div className="container-fluid mobile-gutter">
       <div className="row mobile-gutter">
         <Sidebar
-         isSidebarOpen={isSidebarOpen}
-         adminsNewsIndexPath="/admins/news"
-         newAdminsNewsPath="/admins/news/new"
-         adminsArticlesPath="/admins/articles"
-         newAdminsArticlesPath="/admins/articles/new"
-         adminsShopsPath="/admins/shops"
-         discardedAdminsShopsPath="/admins/shops/discarded"
-         newAdminsShopsPath="/admins/shops/new"
-         newAdminsAdminUsersPath="/admins/admin_users/new"
-         adminsAdminUsersPath="/admins/admin_users"
+          currentAdminRole={props.currentAdminRole}
+          isSidebarOpen={isSidebarOpen}
+          adminsNewsIndexPath="/admins/news"
+          newAdminsNewsPath="/admins/news/new"
+          adminsArticlesPath="/admins/articles"
+          newAdminsArticlesPath="/admins/articles/new"
+          adminsShopsPath="/admins/shops"
+          discardedAdminsShopsPath="/admins/shops/discarded"
+          newAdminsShopsPath="/admins/shops/new"
+          newAdminsAdminUsersPath="/admins/admin_users/new"
+          adminsAdminUsersPath="/admins/admin_users"
          ></Sidebar>
         <main className={`${isSidebarOpen ? 'ml-sm-auto col-lg-10 col-md-9' : ''}  px-md-4 py-md-4 main-top`}>
           {props.children}

--- a/app/frontend/src/Header.tsx
+++ b/app/frontend/src/Header.tsx
@@ -4,12 +4,15 @@ interface HeaderProps {
   adminsRootPath: string;
   destroyAdminSessionPath: string;
   isSidebarOpen: boolean;
-  currentAdminName: string;
-  currentAdminRole: string;
+  currentAdmin: {
+    currentAdminName: string;
+    currentAdminRole: string;
+  };
   toggleSidebar: () => void;
 }
 
 const Header: React.FC<HeaderProps> = (props) => {
+  console.log(props.currentAdmin);
   const handleLogoutClick = (e: React.MouseEvent<HTMLAnchorElement>) => {
     const confirmLogout = window.confirm('本当にログアウトしますか？');
     if (!confirmLogout) {
@@ -59,12 +62,12 @@ const Header: React.FC<HeaderProps> = (props) => {
             <ul className="dropdown-menu dropdown-menu-end position-absolute" aria-labelledby="navbarDropdown">
               <li>
                 <div className="dropdown-item">
-                  {props.currentAdminRole}
+                {props.currentAdmin.currentAdminRole}
                 </div>
               </li>
               <li>
                 <div className="dropdown-item">
-                  {props.currentAdminName}
+                {props.currentAdmin.currentAdminName}
                 </div>
               </li>
               <li>

--- a/app/frontend/src/Header.tsx
+++ b/app/frontend/src/Header.tsx
@@ -2,9 +2,10 @@ import React from 'react';
 
 interface HeaderProps {
   adminsRootPath: string;
-  editAdminRegistrationPath: string;
   destroyAdminSessionPath: string;
   isSidebarOpen: boolean;
+  currentAdminName: string;
+  currentAdminRole: string;
   toggleSidebar: () => void;
 }
 
@@ -50,9 +51,18 @@ const Header: React.FC<HeaderProps> = (props) => {
             </a>
             <ul className="dropdown-menu dropdown-menu-end position-absolute" aria-labelledby="navbarDropdown">
               <li>
-                <a href={props.editAdminRegistrationPath} className="dropdown-item">
-                  アカウント設定
-                </a>
+                <div
+                  className="dropdown-item"
+                >
+                  {props.currentAdminRole}
+                </div>
+              </li>
+              <li>
+                <div
+                  className="dropdown-item"
+                >
+                  {props.currentAdminName}
+                </div>
               </li>
               <li>
                 <a

--- a/app/frontend/src/Header.tsx
+++ b/app/frontend/src/Header.tsx
@@ -10,6 +10,13 @@ interface HeaderProps {
 }
 
 const Header: React.FC<HeaderProps> = (props) => {
+  const handleLogoutClick = (e: React.MouseEvent<HTMLAnchorElement>) => {
+    const confirmLogout = window.confirm('本当にログアウトしますか？');
+    if (!confirmLogout) {
+      e.preventDefault();
+    }
+  };
+
   return (
     <header>
       <nav className="navbar navbar-expand navbar-dark bg-dark">
@@ -51,16 +58,12 @@ const Header: React.FC<HeaderProps> = (props) => {
             </a>
             <ul className="dropdown-menu dropdown-menu-end position-absolute" aria-labelledby="navbarDropdown">
               <li>
-                <div
-                  className="dropdown-item"
-                >
+                <div className="dropdown-item">
                   {props.currentAdminRole}
                 </div>
               </li>
               <li>
-                <div
-                  className="dropdown-item"
-                >
+                <div className="dropdown-item">
                   {props.currentAdminName}
                 </div>
               </li>
@@ -69,7 +72,7 @@ const Header: React.FC<HeaderProps> = (props) => {
                   href={props.destroyAdminSessionPath}
                   className="dropdown-item"
                   data-method="delete"
-                  data-confirm="ログアウトしますか？"
+                  onClick={handleLogoutClick}
                 >
                   ログアウト
                 </a>

--- a/app/frontend/src/Sidebar.tsx
+++ b/app/frontend/src/Sidebar.tsx
@@ -10,6 +10,7 @@ interface SidebarProps {
   newAdminsShopsPath: string;
   adminsAdminUsersPath: string;
   newAdminsAdminUsersPath: string;
+  currentAdminRole: string;
   isSidebarOpen: boolean;
 }
 
@@ -57,17 +58,19 @@ const Sidebar: React.FC<SidebarProps> = (props) => {
             </div>
           </li>
           <li className="border-top my-3"></li>
-          <li className="mb-1">
-            <button className="btn btn-toggle d-inline-flex align-items-center rounded border-0 text-white" data-bs-toggle="collapse" data-bs-target="#admin-user-collapse" aria-expanded="false">
-              アカウント
-            </button>
-            <div className="collapse" id="admin-user-collapse">
-              <ul className="btn-toggle-nav list-unstyled fw-normal pb-1 small">
-                <li><a href={props.adminsAdminUsersPath} className="link-body-emphasis d-inline-flex text-decoration-none rounded text-white">管理ユーザー一覧</a></li>
-                <li><a href={props.newAdminsAdminUsersPath} className="link-body-emphasis d-inline-flex text-decoration-none rounded text-white">管理ユーザ新規作成</a></li>
-              </ul>
-            </div>
-          </li>
+          {props.currentAdminRole !== 'メンバー' && (
+            <li className="mb-1">
+              <button className="btn btn-toggle d-inline-flex align-items-center rounded border-0 text-white" data-bs-toggle="collapse" data-bs-target="#admin-user-collapse" aria-expanded="false">
+                アカウント
+              </button>
+              <div className="collapse" id="admin-user-collapse">
+                <ul className="btn-toggle-nav list-unstyled fw-normal pb-1 small">
+                  <li><a href={props.adminsAdminUsersPath} className="link-body-emphasis d-inline-flex text-decoration-none rounded text-white">管理ユーザー一覧</a></li>
+                  <li><a href={props.newAdminsAdminUsersPath} className="link-body-emphasis d-inline-flex text-decoration-none rounded text-white">管理ユーザ新規作成</a></li>
+                </ul>
+              </div>
+            </li>
+          )}
         </ul>
       </div>
     </nav>

--- a/app/frontend/src/Sidebar.tsx
+++ b/app/frontend/src/Sidebar.tsx
@@ -8,6 +8,8 @@ interface SidebarProps {
   adminsShopsPath: string;
   discardedAdminsShopsPath: string;
   newAdminsShopsPath: string;
+  adminsAdminUsersPath: string;
+  newAdminsAdminUsersPath: string;
   isSidebarOpen: boolean;
 }
 
@@ -56,15 +58,13 @@ const Sidebar: React.FC<SidebarProps> = (props) => {
           </li>
           <li className="border-top my-3"></li>
           <li className="mb-1">
-            <button className="btn btn-toggle d-inline-flex align-items-center rounded border-0 text-white" data-bs-toggle="collapse" data-bs-target="#account-collapse" aria-expanded="false">
+            <button className="btn btn-toggle d-inline-flex align-items-center rounded border-0 text-white" data-bs-toggle="collapse" data-bs-target="#admin-user-collapse" aria-expanded="false">
               アカウント
             </button>
-            <div className="collapse" id="account-collapse">
+            <div className="collapse" id="admin-user-collapse">
               <ul className="btn-toggle-nav list-unstyled fw-normal pb-1 small">
-                <li><a href="#" className="link-body-emphasis d-inline-flex text-decoration-none rounded text-white">新プロジェクト...</a></li>
-                <li><a href="#" className="link-body-emphasis d-inline-flex text-decoration-none rounded text-white">プロフィール</a></li>
-                <li><a href="#" className="link-body-emphasis d-inline-flex text-decoration-none rounded text-white">設定</a></li>
-                <li><a href="#" className="link-body-emphasis d-inline-flex text-decoration-none rounded text-white">サインアウト</a></li>
+                <li><a href={props.adminsAdminUsersPath} className="link-body-emphasis d-inline-flex text-decoration-none rounded text-white">管理ユーザー一覧</a></li>
+                <li><a href={props.newAdminsAdminUsersPath} className="link-body-emphasis d-inline-flex text-decoration-none rounded text-white">管理ユーザ新規作成</a></li>
               </ul>
             </div>
           </li>

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,4 +1,16 @@
 module ApplicationHelper
+  def show_error_messages(object, attribute)
+    if object.errors.full_messages_for(attribute).any?
+      content_tag(:div, class: "text-danger") do
+        content_tag(:ul, class: "mb-0") do
+          object.errors.full_messages_for(attribute).map do |message|
+            content_tag(:li, message)
+          end.join.html_safe
+        end
+      end
+    end
+  end
+
   def format_datetime(datetime)
     datetime.strftime("%Y/ %m/ %d /%H:%M")
   end

--- a/app/models/admin.rb
+++ b/app/models/admin.rb
@@ -15,6 +15,10 @@ class Admin < ApplicationRecord
     %i(search_by_role)
   end
 
+  def data_props
+    { currentAdminName: name, currentAdminRole: role_text }
+  end
+
   def self.ransackable_attributes(auth_object = nil)
     ["name", "role"]
   end

--- a/app/models/admin.rb
+++ b/app/models/admin.rb
@@ -4,7 +4,7 @@ class Admin < ApplicationRecord
   
   extend Enumerize
   enumerize :role, in: { member: 0, admin: 1 }, default: :member, predicates: true
-  devise :database_authenticatable, :registerable,
+  devise :database_authenticatable,
          :recoverable, :rememberable, :validatable
   validates :name,
   length: { minimum: 2, maximum: 20 }

--- a/app/models/admin.rb
+++ b/app/models/admin.rb
@@ -6,7 +6,5 @@ class Admin < ApplicationRecord
   enumerize :role, in: { member: 0, admin: 1 }, default: :member, predicates: true
   devise :database_authenticatable,
          :recoverable, :rememberable, :validatable
-  validates :name,
-  length: { minimum: 2, maximum: 20 }
-  validates :role, presence: true
+  validates :name, length: { minimum: 2, maximum: 20 }
 end

--- a/app/models/admin.rb
+++ b/app/models/admin.rb
@@ -7,4 +7,5 @@ class Admin < ApplicationRecord
   devise :database_authenticatable,
          :recoverable, :rememberable, :validatable
   validates :name, length: { minimum: 2, maximum: 20 }
+  validates :role, presence: true
 end

--- a/app/models/admin.rb
+++ b/app/models/admin.rb
@@ -3,11 +3,17 @@ class Admin < ApplicationRecord
   has_many :job_entries, foreign_key: 'update_by'
   
   extend Enumerize
-  enumerize :role, in: { member: 0, admin: 1, owner: 2 }, default: :member, predicates: true
+  enumerize :role, in: { member: 0, admin: 1, owner: 2 }, default: :member, scope: true, predicates: true
   devise :database_authenticatable,
          :recoverable, :rememberable, :validatable
   validates :name, length: { minimum: 2, maximum: 20 }
   validates :role, presence: true
+
+  scope :search_by_role, ->(role) { where(role: role) }
+
+  def self.ransackable_scopes(auth_object = nil)
+    %i(search_by_role)
+  end
 
   def self.ransackable_attributes(auth_object = nil)
     ["name", "role"]

--- a/app/models/admin.rb
+++ b/app/models/admin.rb
@@ -2,7 +2,7 @@ class Admin < ApplicationRecord
   has_many :contacts, foreign_key: 'update_by'
   has_many :job_entries, foreign_key: 'update_by'
   
-
+  extend Enumerize
   enumerize :role, in: { member: 0, admin: 1 }, default: :member, predicates: true
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable

--- a/app/models/admin.rb
+++ b/app/models/admin.rb
@@ -8,4 +8,12 @@ class Admin < ApplicationRecord
          :recoverable, :rememberable, :validatable
   validates :name, length: { minimum: 2, maximum: 20 }
   validates :role, presence: true
+
+  def self.ransackable_attributes(auth_object = nil)
+    ["name", "role"]
+  end
+
+  def self.ransackable_associations(auth_object = nil)
+    []
+  end
 end

--- a/app/models/admin.rb
+++ b/app/models/admin.rb
@@ -3,7 +3,7 @@ class Admin < ApplicationRecord
   has_many :job_entries, foreign_key: 'update_by'
   
   extend Enumerize
-  enumerize :role, in: { member: 0, admin: 1 }, default: :member, predicates: true
+  enumerize :role, in: { member: 0, admin: 1, owner: 2 }, default: :member, predicates: true
   devise :database_authenticatable,
          :recoverable, :rememberable, :validatable
   validates :name, length: { minimum: 2, maximum: 20 }

--- a/app/models/admin.rb
+++ b/app/models/admin.rb
@@ -1,10 +1,12 @@
 class Admin < ApplicationRecord
   has_many :contacts, foreign_key: 'update_by'
   has_many :job_entries, foreign_key: 'update_by'
-  # Include default devise modules. Others available are:
-  # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
+  
+
+  enumerize :role, in: { member: 0, admin: 1 }, default: :member, predicates: true
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable
   validates :name,
   length: { minimum: 2, maximum: 20 }
+  validates :role, presence: true
 end

--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -12,6 +12,12 @@ class Article < ApplicationRecord
   validate :start_at_in_future
   validate :end_at_after_start_at
 
+  scope :search_by_category, ->(category) { where(category: category) }
+
+  def self.ransackable_scopes(auth_object = nil)
+    %i(search_by_category)
+  end
+
   def start_at_in_future
     errors.add(:start_at, 'は過去の日時を選択できません') if start_at.present? && start_at < Time.zone.now
   end

--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -21,7 +21,7 @@ class Article < ApplicationRecord
   end
 
   def self.ransackable_attributes(auth_object = nil)
-    ["title"]
+    ["title", "category"]
   end
 
   def self.ransackable_associations(auth_object = nil)

--- a/app/views/admins/admin_users/_form.html.erb
+++ b/app/views/admins/admin_users/_form.html.erb
@@ -2,9 +2,9 @@
   <%= f.label :role, class: "form-label" %>
   <span class="badge rounded-pill text-bg-danger">必須</span>
   <% if f.object.new_record? %>
-    <%= f.select :role, Admin.role.options.reject { |_, value| value == 'owner' }, { prompt: '選択してください' }, { selected: f.object.role, class: 'form-select' } %>
+    <%= f.select :role, @new_role_options, { prompt: '選択してください' }, { selected: f.object.role, class: 'form-select' } %>
   <% else %>
-    <%= f.select :role, (f.object.role.owner? ? @fixed_role_owner_options : Admin.role.options.reject { |_, value| value == 'owner' }), { prompt: '選択してください' }, { selected: f.object.role, class: 'form-select' } %>
+    <%= f.select :role, @edit_role_options, { prompt: '選択してください' }, { selected: f.object.role, class: 'form-select' } %>
   <% end %>
   <%= show_error_messages(f.object, :role) %>
 </div>

--- a/app/views/admins/admin_users/_form.html.erb
+++ b/app/views/admins/admin_users/_form.html.erb
@@ -1,7 +1,7 @@
 <div class="mb-4">
   <%= f.label :role, class: "form-label" %>
   <span class="badge rounded-pill text-bg-danger">必須</span>
-  <%= f.select :role, Admin.role.options, { prompt: '選択してください' }, { selected: f.object.role, class: 'form-select' } %>
+  <%= f.select :role, Admin.role.options.reject { |_, value| value == 'owner' }, { prompt: '選択してください' }, { selected: f.object.role, class: 'form-select' } %>
   <%= render "layouts/error_messages", object: f.object, attribute: :role %>
 </div>
 

--- a/app/views/admins/admin_users/_form.html.erb
+++ b/app/views/admins/admin_users/_form.html.erb
@@ -1,7 +1,11 @@
 <div class="mb-4">
   <%= f.label :role, class: "form-label" %>
   <span class="badge rounded-pill text-bg-danger">必須</span>
-  <%= f.select :role, (current_admin.role.owner? ? Admin.role.options : Admin.role.options.reject { |_, value| value == 'owner' }), { prompt: '選択してください' }, { selected: f.object.role, class: 'form-select' } %>
+  <% if f.object.new_record? %>
+    <%= f.select :role, Admin.role.options.reject { |_, value| value == 'owner' }, { prompt: '選択してください' }, { selected: f.object.role, class: 'form-select' } %>
+  <% else %>
+    <%= f.select :role, (f.object.role.owner? ? @fixed_role_owner_options : Admin.role.options.reject { |_, value| value == 'owner' }), { prompt: '選択してください' }, { selected: f.object.role, class: 'form-select' } %>
+  <% end %>
   <%= render "layouts/error_messages", object: f.object, attribute: :role %>
 </div>
 

--- a/app/views/admins/admin_users/_form.html.erb
+++ b/app/views/admins/admin_users/_form.html.erb
@@ -1,0 +1,51 @@
+<div class="mb-4">
+  <%= f.label :role, class: "form-label" %>
+  <span class="badge rounded-pill text-bg-danger">必須</span>
+  <%= f.select :role, Admin.role.options, { prompt: '選択してください' }, { selected: f.object.role, class: 'form-select' } %>
+  <%= render "layouts/error_messages", object: f.object, attribute: :role %>
+</div>
+
+<div class="mb-4">
+  <%= f.label :name, class: "form-label mt-3" %>
+  <span class="badge rounded-pill text-bg-danger">必須</span>
+  <%= f.text_field :name, autofocus: true, autocomplete: "name", class: "form-control", placeholder: "食べ物太郎" %>
+  <%= render "layouts/error_messages", object: f.object, attribute: :name %>
+</div>
+
+<div class="mb-4">
+  <%= f.label :email, class: "form-label mt-3" %>
+  <span class="badge rounded-pill text-bg-danger">必須</span>
+  <%= f.email_field :email, autocomplete: "email", class: "form-control", placeholder: "mail@example.com" %>
+  <%= render "layouts/error_messages", object: f.object, attribute: :email %>
+</div>
+
+<div class="mb-4">
+  <%= f.label :password, class: "form-label mt-3" %>
+  <span class="badge rounded-pill text-bg-danger">必須</span>
+  <%= f.password_field :password, class: "form-control", placeholder: "半角英数6文字以上" %>
+  <%= render "layouts/error_messages", object: f.object, attribute: :password %>
+</div>
+
+<div class="mb-4">
+  <%= f.label :password_confirmation, class: "form-label mt-3" %>
+  <span class="badge rounded-pill text-bg-danger">必須</span>
+  <%= f.password_field :password_confirmation, class: "form-control", placeholder: "半角英数6文字以上" %>
+  <%= render "layouts/error_messages", object: f.object, attribute: :password_confirmation %>
+</div>
+
+
+<% if f.object.new_record? %>
+  <div class="mt-5">
+    <ul class="list-inline">
+      <li class="list-inline-item"><%= f.submit "登録完了する", class: 'btn btn-primary' %></li>
+      <li class="list-inline-item"><%= link_to "管理ユーザー一覧に戻る", @admin_users_index_url, class: 'btn btn-secondary' %></li>
+    </ul>
+  </div>
+<% else %>
+  <div class="mt-5">
+    <ul class="list-inline">
+      <li class="list-inline-item"><%= f.submit "編集を完了する", class: 'btn btn-primary' %></li>
+      <li class="list-inline-item"><%= link_to "管理ユーザー一覧に戻る", @admin_users_index_url, class: 'btn btn-secondary' %></li>
+    </ul>
+  </div>
+<% end %>

--- a/app/views/admins/admin_users/_form.html.erb
+++ b/app/views/admins/admin_users/_form.html.erb
@@ -6,37 +6,36 @@
   <% else %>
     <%= f.select :role, (f.object.role.owner? ? @fixed_role_owner_options : Admin.role.options.reject { |_, value| value == 'owner' }), { prompt: '選択してください' }, { selected: f.object.role, class: 'form-select' } %>
   <% end %>
-  <%= render "layouts/error_messages", object: f.object, attribute: :role %>
+  <%= show_error_messages(f.object, :role) %>
 </div>
 
 <div class="mb-4">
   <%= f.label :name, class: "form-label mt-3" %>
   <span class="badge rounded-pill text-bg-danger">必須</span>
   <%= f.text_field :name, autofocus: true, autocomplete: "name", class: "form-control", placeholder: "食べ物太郎" %>
-  <%= render "layouts/error_messages", object: f.object, attribute: :name %>
+  <%= show_error_messages(f.object, :name) %>
 </div>
 
 <div class="mb-4">
   <%= f.label :email, class: "form-label mt-3" %>
   <span class="badge rounded-pill text-bg-danger">必須</span>
   <%= f.email_field :email, autocomplete: "email", class: "form-control", placeholder: "mail@example.com" %>
-  <%= render "layouts/error_messages", object: f.object, attribute: :email %>
+  <%= show_error_messages(f.object, :email) %>
 </div>
 
 <div class="mb-4">
   <%= f.label :password, class: "form-label mt-3" %>
   <span class="badge rounded-pill text-bg-danger">必須</span>
   <%= f.password_field :password, class: "form-control", placeholder: "半角英数6文字以上" %>
-  <%= render "layouts/error_messages", object: f.object, attribute: :password %>
+  <%= show_error_messages(f.object, :password) %>
 </div>
 
 <div class="mb-4">
   <%= f.label :password_confirmation, class: "form-label mt-3" %>
   <span class="badge rounded-pill text-bg-danger">必須</span>
   <%= f.password_field :password_confirmation, class: "form-control", placeholder: "半角英数6文字以上" %>
-  <%= render "layouts/error_messages", object: f.object, attribute: :password_confirmation %>
+  <%= show_error_messages(f.object, :password_confirmation) %>
 </div>
-
 
 <% if f.object.new_record? %>
   <div class="mt-5">

--- a/app/views/admins/admin_users/_form.html.erb
+++ b/app/views/admins/admin_users/_form.html.erb
@@ -1,7 +1,7 @@
 <div class="mb-4">
   <%= f.label :role, class: "form-label" %>
   <span class="badge rounded-pill text-bg-danger">必須</span>
-  <%= f.select :role, Admin.role.options.reject { |_, value| value == 'owner' }, { prompt: '選択してください' }, { selected: f.object.role, class: 'form-select' } %>
+  <%= f.select :role, (current_admin.role.owner? ? Admin.role.options : Admin.role.options.reject { |_, value| value == 'owner' }), { prompt: '選択してください' }, { selected: f.object.role, class: 'form-select' } %>
   <%= render "layouts/error_messages", object: f.object, attribute: :role %>
 </div>
 

--- a/app/views/admins/admin_users/edit.html.erb
+++ b/app/views/admins/admin_users/edit.html.erb
@@ -1,0 +1,11 @@
+<div class="container mt-4 mobile-gutter">
+  <%= render "admins/shared/flashes" %>
+  <div class="card col-sm-9 mx-auto mt-5 mobile-card-border">
+    <div class="card-body">
+      <h3 class="text-center mt-3 mb-5 fw-bold">管理ユーザー情報編集</h3>
+      <%= form_with model: @admin_user, url: admins_admin_user_path, local: true do |f| %>
+        <%= render partial: 'form', locals: { f: f } %>
+      <% end %>
+    </div>
+  </div>
+</div>

--- a/app/views/admins/admin_users/index.html.erb
+++ b/app/views/admins/admin_users/index.html.erb
@@ -1,0 +1,37 @@
+<div class="container mt-4 mobile-gutter p-3">
+  <div class="d-flex justify-content-between mb-4 mobile-block">
+    <h3 class="fw-bold"><%= link_to '管理者一覧', admins_admin_users_path, class: 'text-dark text-decoration-none' %></h3>
+  </div>
+  <%= render "admins/shared/flashes" %>
+  <div class="table-responsive">
+    <table class="table table-hover">
+      <thead class="table-dark">
+        <tr>
+          <th>権限</th>
+          <th>名前</th>
+          <th>メールアドレス</th>
+          <th colspan="2"></th>
+        </tr>
+      </thead>
+      <tbody>
+        <% @admin_users.each do |admin_user| %>
+          <tr>
+            <td class="align-middle"><%= admin_user.role_text %></td>
+            <td class="align-middle"><%= link_to admin_user.name, admins_admin_user_path(admin_user), class: "text-primary" %></td>
+            <td class="align-middle"><%= admin_user.email %></td>
+            <td class="text-center align-middle">
+              <%= link_to "編集", edit_admins_admin_user_path(admin_user), class: "btn btn-outline-primary btn-sm" %>
+            </td>
+            <td class="text-start align-middle">
+              <%= button_to "削除", admins_admin_user_path(admin_user), { method: :delete, class: "btn btn-outline-danger btn-sm", onclick: "return confirm('本当に削除しますか？');" } %>
+            </td>
+          </tr>
+        <% end %>
+      </tbody>
+    </table>
+  </div>
+
+  <p><%= link_to "管理ユーザー新規登録", new_admins_admin_user_path, class: 'btn btn-primary' %></p>
+</div>
+
+<%= paginate @admin_users, theme: 'bootstrap-5' %>

--- a/app/views/admins/admin_users/index.html.erb
+++ b/app/views/admins/admin_users/index.html.erb
@@ -19,12 +19,16 @@
             <td class="align-middle"><%= admin_user.role_text %></td>
             <td class="align-middle"><%= link_to admin_user.name, admins_admin_user_path(admin_user), class: "text-primary" %></td>
             <td class="align-middle"><%= admin_user.email %></td>
-            <td class="text-center align-middle">
-              <%= link_to "編集", edit_admins_admin_user_path(admin_user), class: "btn btn-outline-primary btn-sm" %>
-            </td>
-            <td class="text-start align-middle">
-              <%= button_to "削除", admins_admin_user_path(admin_user), { method: :delete, class: "btn btn-outline-danger btn-sm", onclick: "return confirm('本当に削除しますか？');" } %>
-            </td>
+            <% if current_admin && (admin_user.id != 1 || current_admin.id == 1) %>
+              <td class="text-center align-middle">
+                <%= link_to "編集", edit_admins_admin_user_path(admin_user), class: "btn btn-outline-primary btn-sm" %>
+              </td>
+              <td class="text-start align-middle">
+                <%= button_to "削除", admins_admin_user_path(admin_user), { method: :delete, class: "btn btn-outline-danger btn-sm", onclick: "return confirm('本当に削除しますか？');" } %>
+              </td>
+            <% else %>
+              <td colspan="2" class="text-center align-middle"></td>
+            <% end %>
           </tr>
         <% end %>
       </tbody>

--- a/app/views/admins/admin_users/index.html.erb
+++ b/app/views/admins/admin_users/index.html.erb
@@ -1,6 +1,15 @@
 <div class="container mt-4 mobile-gutter p-3">
   <div class="d-flex justify-content-between mb-4 mobile-block">
     <h3 class="fw-bold"><%= link_to '管理者一覧', admins_admin_users_path, class: 'text-dark text-decoration-none' %></h3>
+    <%= search_form_for @q, url: admins_admin_users_path, class: 'form-inline' do |f| %>
+      <div class="input-group">
+        <%= f.select :role_eq, Admin.role.values.collect(&:text), { include_blank: '全ての権限' }, class: 'me-4' %>
+        <%= f.search_field :name_cont, class: 'form-control', placeholder: '名前で検索' %>
+        <div class="input-group-append">
+          <%= f.submit '検索', class: 'btn btn-primary' %>
+        </div>
+      </div>
+    <% end %>
   </div>
   <%= render "admins/shared/flashes" %>
   <div class="table-responsive">

--- a/app/views/admins/admin_users/index.html.erb
+++ b/app/views/admins/admin_users/index.html.erb
@@ -3,7 +3,7 @@
     <h3 class="fw-bold"><%= link_to '管理者一覧', admins_admin_users_path, class: 'text-dark text-decoration-none' %></h3>
     <%= search_form_for @q, url: admins_admin_users_path, class: 'form-inline' do |f| %>
       <div class="input-group">
-        <%= f.select :role_eq, Admin.role.values.collect(&:text), { include_blank: '全ての権限' }, class: 'me-4' %>
+        <%= f.select :role_eq, Admin.role.values.collect(&:text), { include_blank: '全ての権限' }, class: 'form-select-sm me-4' %>
         <%= f.search_field :name_cont, class: 'form-control', placeholder: '名前で検索' %>
         <div class="input-group-append">
           <%= f.submit '検索', class: 'btn btn-primary' %>

--- a/app/views/admins/admin_users/index.html.erb
+++ b/app/views/admins/admin_users/index.html.erb
@@ -3,7 +3,7 @@
     <h3 class="fw-bold"><%= link_to '管理者一覧', admins_admin_users_path, class: 'text-dark text-decoration-none' %></h3>
     <%= search_form_for @q, url: admins_admin_users_path, class: 'form-inline' do |f| %>
       <div class="input-group">
-        <%= f.select :role_eq, Admin.role.values.collect(&:text), { include_blank: '全ての権限' }, class: 'form-select-sm me-4' %>
+        <%= f.select :search_by_role, Admin.role.options, { include_blank: '全ての権限' }, class: 'form-select-sm me-4' %>
         <%= f.search_field :name_cont, class: 'form-control', placeholder: '名前で検索' %>
         <div class="input-group-append">
           <%= f.submit '検索', class: 'btn btn-primary' %>

--- a/app/views/admins/admin_users/new.html.erb
+++ b/app/views/admins/admin_users/new.html.erb
@@ -1,0 +1,11 @@
+<div class="container mt-4 mobile-gutter">
+  <%= render "admins/shared/flashes" %>
+  <div class="card col-sm-9 mx-auto mt-5 mobile-card-border">
+    <div class="card-body">
+      <h3 class="text-center mt-3 mb-5 fw-bold">管理者新規登録</h3>
+      <%= form_with model: @admin_user, url: admins_admin_users_path, local: true  do |f| %>
+        <%= render partial: 'form', locals: { f: f } %>
+      <% end %>
+    </div>
+  </div>
+</div>

--- a/app/views/admins/admin_users/show.html.erb
+++ b/app/views/admins/admin_users/show.html.erb
@@ -1,0 +1,32 @@
+<div class="container mt-4">
+  <%= render "admins/shared/flashes" %>
+  <div class="card col-sm-9 mx-auto mt-5">
+    <div class="card-body p-5 mx-5">
+      <h2 class="mb-4 text-center fw-bold"><%= @admin_user.name %>の詳細情報</h2>
+      
+      <div class="border-bottom pt-3 mb-3">
+        <h3 class="ml-2">役割</h3>
+        <p class="text-center"><%= @admin_user.role_text %></p>
+      </div>
+      
+      <div class="border-bottom pt-3 mb-3">
+        <h3 class="">名前</h3>
+        <p class="text-center"><%= @admin_user.name %></p>
+      </div>
+      
+      <div class="border-bottom pt-3 mb-3">
+        <h3 class="">メールアドレス</h3>
+        <p class="text-center"><%= @admin_user.email %></p>
+      </div>
+      
+      <div class="pt-3 mb-3">
+        <h3 class="">パスワード</h3>
+        <p class="text-center">******</p>
+      </div>
+      
+      <div class="mt-5">
+        <%= link_to "一覧に戻る", @admin_users_index_url, class: 'btn btn-secondary' %>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/admins/articles/_form.html.erb
+++ b/app/views/admins/articles/_form.html.erb
@@ -2,36 +2,35 @@
   <%= f.label :category, class: "form-label" %>
   <span class="badge rounded-pill text-bg-danger">必須</span>
   <%= f.select :category, Article.category.options, { prompt: '選択してください' }, { selected: f.object.category, class: 'form-select' } %>
-  <%= render "layouts/error_messages", object: f.object, attribute: :category %>
+  <%= show_error_messages(f.object, :category) %>
 </div>
 
 <div class="mb-4">
   <%= f.label :title, class: "form-label" %>
   <span class="badge rounded-pill text-bg-danger">必須</span>
   <%= f.text_field :title, class: 'form-control', value: f.object.title, placeholder: "社員旅行など" %>
-  <%= render "layouts/error_messages", object: f.object, attribute: :title %>
+  <%= show_error_messages(f.object, :title) %>
 </div>
 
 <div class="mb-4">
   <%= f.label :start_at, class: "form-label" %>
   <span class="badge rounded-pill text-bg-danger">必須</span>
   <%= f.datetime_field :start_at, class: 'form-control', **@start_at_options, value: f.object.start_at&.strftime("%Y-%m-%dT%H:%M") %>
-  <%= render "layouts/error_messages", object: f.object, attribute: :start_at %>
+  <%= show_error_messages(f.object, :start_at) %>
 </div>
 
 <div class="mb-4">
   <%= f.label :end_at, class: "form-label" %>
   <span class="badge rounded-pill text-bg-danger">必須</span>
   <%= f.datetime_field :end_at, class: 'form-control', **@end_at_options, value: f.object.end_at&.strftime("%Y-%m-%dT%H:%M") %>
-  <%= render "layouts/error_messages", object: f.object, attribute: :end_at %>
+  <%= show_error_messages(f.object, :end_at) %>
 </div>
 
-
 <div class="mb-4">
-    <articlecontents-component
-      data-props="<%= { contents: f.object.contents, body_error_message: "内容を入力してください" }.to_json %>"
-    >
-    </articlecontents-component>
+  <articlecontents-component
+    data-props="<%= { contents: f.object.contents, body_error_message: "内容を入力してください" }.to_json %>"
+  >
+  </articlecontents-component>
 </div>
 
 <% if f.object.new_record? %>

--- a/app/views/admins/articles/index.html.erb
+++ b/app/views/admins/articles/index.html.erb
@@ -3,6 +3,7 @@
     <h3 class="fw-bold"><%= link_to 'ブログ一覧', admins_articles_path, class: 'text-dark text-decoration-none' %></h3>
     <%= search_form_for @q, url: admins_articles_path, class: 'form-inline' do |f| %>
       <div class="input-group">
+        <%= f.select :category_eq, Article.category.values.collect(&:text), { include_blank: '全てのカテゴリー' }, class: 'form-select-sm me-4' %>
         <%= f.search_field :title_cont, class: 'form-control', placeholder: 'タイトルで検索' %>
         <div class="input-group-append">
           <%= f.submit '検索', class: 'btn btn-primary' %>

--- a/app/views/admins/articles/index.html.erb
+++ b/app/views/admins/articles/index.html.erb
@@ -3,7 +3,7 @@
     <h3 class="fw-bold"><%= link_to 'ブログ一覧', admins_articles_path, class: 'text-dark text-decoration-none' %></h3>
     <%= search_form_for @q, url: admins_articles_path, class: 'form-inline' do |f| %>
       <div class="input-group">
-        <%= f.select :category_eq, Article.category.values.collect(&:text), { include_blank: '全てのカテゴリー' }, class: 'form-select-sm me-4' %>
+        <%= f.select :search_by_category, Article.category.options, { include_blank: '全てのカテゴリー' }, class: 'form-select-sm me-4' %>
         <%= f.search_field :title_cont, class: 'form-control', placeholder: 'タイトルで検索' %>
         <div class="input-group-append">
           <%= f.submit '検索', class: 'btn btn-primary' %>

--- a/app/views/admins/news/_form.html.erb
+++ b/app/views/admins/news/_form.html.erb
@@ -2,35 +2,35 @@
   <%= f.label :calendar_date, class: "form-label" %>
   <span class="badge rounded-pill text-bg-danger">必須</span>
   <%= f.date_field :calendar_date, class: 'form-control', **@calendar_date_options, value: f.object.calendar_date %>
-  <%= render "layouts/error_messages", object: f.object, attribute: :calendar_date %>
+  <%= show_error_messages(f.object, :calendar_date) %>
 </div>
 
 <div class="mb-4">
   <%= f.label :title, class: "form-label" %>
   <span class="badge rounded-pill text-bg-danger">必須</span>
   <%= f.text_field :title, class: 'form-control', value: f.object.title %>
-  <%= render "layouts/error_messages", object: f.object, attribute: :title %>
+  <%= show_error_messages(f.object, :title) %>
 </div>
 
 <div class="mb-4">
   <%= f.label :start_at, class: "form-label" %>
   <span class="badge rounded-pill text-bg-danger">必須</span>
   <%= f.datetime_field :start_at, class: 'form-control', **@start_at_options, value: f.object.start_at&.strftime("%Y-%m-%dT%H:%M") %>
-  <%= render "layouts/error_messages", object: f.object, attribute: :start_at %>
+  <%= show_error_messages(f.object, :start_at) %>
 </div>
 
 <div class="mb-4">
   <%= f.label :end_at, class: "form-label" %>
   <span class="badge rounded-pill text-bg-danger">必須</span>
   <%= f.datetime_field :end_at, class: 'form-control', **@end_at_options, value: f.object.end_at&.strftime("%Y-%m-%dT%H:%M") %>
-  <%= render "layouts/error_messages", object: f.object, attribute: :end_at %>
+  <%= show_error_messages(f.object, :end_at) %>
 </div>
 
 <div class="mb-4">
   <%= f.label :body, class: "form-label" %>
   <span class="badge rounded-pill text-bg-danger">必須</span>
   <%= f.text_area :body, class: 'form-control', value: f.object.body %>
-  <%= render "layouts/error_messages", object: f.object, attribute: :body %>
+  <%= show_error_messages(f.object, :body) %>
 </div>
 
 <% if f.object.new_record? %>
@@ -48,4 +48,3 @@
     </ul>
   </div>
 <% end %>
-

--- a/app/views/admins/shops/_form.html.erb
+++ b/app/views/admins/shops/_form.html.erb
@@ -2,77 +2,77 @@
   <%= f.label :name, class: "form-label" %>
   <span class="badge rounded-pill text-bg-danger">必須</span>
   <%= f.text_field :name, class: 'form-control', value: f.object.name, placeholder: "焼き鳥とおつまみ佐藤 大阪店" %>
-  <%= render "layouts/error_messages", object: f.object, attribute: :name %>
+  <%= show_error_messages(f.object, :name) %>
 </div>
 
 <div class="mb-4">
   <%= f.label :prefecture_id, class: "form-label" %>
   <span class="badge rounded-pill text-bg-danger">必須</span>
   <%= f.collection_select :prefecture_id, @prefectures, :id, :name, { prompt: "選択してください" }, { selected: f.object.prefecture_id, class: 'form-select' } %>
-  <%= render "layouts/error_messages", object: f.object, attribute: :prefecture_id %>
+  <%= show_error_messages(f.object, :prefecture_id) %>
 </div>
 
 <div class="mb-4">
   <%= f.label :city_name, class: "form-label" %>
   <span class="badge rounded-pill text-bg-danger">必須</span>
   <%= f.text_field :city_name, class: 'form-control', value: f.object.city_name, placeholder: "大阪市北区" %>
-  <%= render "layouts/error_messages", object: f.object, attribute: :city_name %>
+  <%= show_error_messages(f.object, :city_name) %>
 </div>
 
 <div class="mb-4">
   <%= f.label :address, class: "form-label" %>
   <span class="badge rounded-pill text-bg-danger">必須</span>
   <%= f.text_field :address, class: 'form-control', value: f.object.address, placeholder: "梅田1丁目1-1" %>
-  <%= render "layouts/error_messages", object: f.object, attribute: :address %>
+  <%= show_error_messages(f.object, :address) %>
 </div>
 
 <div class="mb-4">
   <%= f.label :business_time, class: "form-label" %>
   <span class="badge rounded-pill text-bg-danger">必須</span>
   <%= f.text_field :business_time, class: 'form-control', value: f.object.business_time, placeholder: "17:00～24:00（L.O.23:00）土日祝だけ昼12:00から営業" %>
-  <%= render "layouts/error_messages", object: f.object, attribute: :business_time %>
+  <%= show_error_messages(f.object, :business_time) %>
 </div>
 
 <div class="mb-4">
   <%= f.label :access, class: "form-label" %>
   <span class="badge rounded-pill text-bg-danger">必須</span>
   <%= f.text_field :access, class: 'form-control', value: f.object.access, placeholder: "ＪＲ大阪環状線 大阪 徒歩4分" %>
-  <%= render "layouts/error_messages", object: f.object, attribute: :access %>
+  <%= show_error_messages(f.object, :access) %>
 </div>
 
 <div class="mb-4">
   <%= f.label :phone_number, class: "form-label" %>
   <span class="badge rounded-pill text-bg-danger">必須</span>
   <%= f.text_field :phone_number, class: 'form-control', value: f.object.phone_number, placeholder: "012-3456-789" %>
-  <%= render "layouts/error_messages", object: f.object, attribute: :phone_number %>
+  <%= show_error_messages(f.object, :phone_number) %>
 </div>
 
 <div class="mb-4">
   <%= f.label :counter_seat, class: "form-label" %>
   <span class="badge rounded-pill text-bg-danger">必須</span>
   <%= f.number_field :counter_seat, class: 'form-control', value: f.object.counter_seat, placeholder: "数字だけを入力" %>
-  <%= render "layouts/error_messages", object: f.object, attribute: :counter_seat %>
+  <%= show_error_messages(f.object, :counter_seat) %>
 </div>
 
 <div class="mb-4">
   <%= f.label :table_seat, class: "form-label" %>
   <span class="badge rounded-pill text-bg-danger">必須</span>
   <%= f.number_field :table_seat, class: 'form-control', value: f.object.table_seat, placeholder: "数字だけを入力" %>
-  <%= render "layouts/error_messages", object: f.object, attribute: :table_seat %>
+  <%= show_error_messages(f.object, :table_seat) %>
 </div>
 
 <div class="mb-4">
   <%= f.label :site_name, class: "form-label" %>
   <span class="badge rounded-pill text-bg-danger">必須</span>
   <%= f.text_field :site_name, class: 'form-control', value: f.object.site_name, placeholder: "食べログ" %>
-  <%= render "layouts/error_messages", object: f.object, attribute: :site_name %>
+  <%= show_error_messages(f.object, :site_name) %>
 </div>
 
 <div class="mb-4">
   <%= f.label :gourmet_site_link, class: "form-label" %>
   <span class="badge rounded-pill text-bg-danger">必須</span>
   <%= f.text_field :gourmet_site_link, class: 'form-control', value: f.object.gourmet_site_link, placeholder: "店舗のグルメサイトのリンクを入力" %>
-  <%= render "layouts/error_messages", object: f.object, attribute: :gourmet_site_link %>
+  <%= show_error_messages(f.object, :gourmet_site_link) %>
 </div>
 
 <div class="mb-4">
@@ -82,7 +82,6 @@
   <%= f.hidden_field :shop_image_cache %>
   <span class="text-muted small mt-2">・5MBまでの画像をアップロードできます。</span>
 </div>
-
 
 <% if f.object.new_record? %>
   <div class="mt-5">

--- a/app/views/layouts/_error_messages.html.erb
+++ b/app/views/layouts/_error_messages.html.erb
@@ -1,9 +1,0 @@
-<% if object.errors.full_messages_for(attribute).any? %>
-  <div class="text-danger">
-    <ul class="mb-0">
-      <% object.errors.full_messages_for(attribute).each do |message| %>
-        <li><%= message %></li>
-      <% end %>
-    </ul>
-  </div>
-<% end %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -26,7 +26,7 @@
   <body>
     <% if admin_signed_in? %>
       <%= vite_javascript_tag 'Application.tsx' %>
-      <app-component>
+      <app-component data-props="<%= { currentAdminName: current_admin.name, currentAdminRole: current_admin.role_text }.to_json %>">
         <%= yield %>
       </app-component>
     <% else %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -26,9 +26,8 @@
   <body>
     <% if admin_signed_in? %>
       <%= vite_javascript_tag 'Application.tsx' %>
-      <app-component data-props="<%= { currentAdminName: current_admin.name, currentAdminRole: current_admin.role_text }.to_json %>">
-        <%= yield %>
-      </app-component>
+        <app-component data-props="<%= { currentAdmin: current_admin.data_props }.to_json %>">
+      <%= yield %>
     <% else %>
       <%= yield %>
     <% end %>

--- a/config/locales/devise.ja.yml
+++ b/config/locales/devise.ja.yml
@@ -10,7 +10,7 @@ ja:
         current_sign_in_at: 現在のログイン時刻
         current_sign_in_ip: 現在のログインIPアドレス
         email: メールアドレス
-        role: 役割
+        role: 権限
         name: 名前
         encrypted_password: 暗号化パスワード
         failed_attempts: 失敗したログイン試行回数

--- a/config/locales/devise.ja.yml
+++ b/config/locales/devise.ja.yml
@@ -10,6 +10,7 @@ ja:
         current_sign_in_at: 現在のログイン時刻
         current_sign_in_ip: 現在のログインIPアドレス
         email: メールアドレス
+        role: 役割
         name: 名前
         encrypted_password: 暗号化パスワード
         failed_attempts: 失敗したログイン試行回数

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -106,6 +106,10 @@ ja:
         article_image: ブログ画像
   
   enumerize:
+    admin:
+      role:
+        member: メンバー
+        admin: 管理者
     article:
       category:
         event: 会社イベント

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -110,6 +110,7 @@ ja:
       role:
         member: メンバー
         admin: 管理者
+        owner: オーナー
     article:
       category:
         event: 会社イベント

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,5 @@
 Rails.application.routes.draw do
-  devise_for :admins, controllers: {
-    registrations: 'admins/registrations'
-  }
+  devise_for :admins
 
   devise_scope :admin do
     get '/admins/sign_out' => 'devise/sessions#destroy'
@@ -24,5 +22,6 @@ Rails.application.routes.draw do
       end
     end
     resources :articles
+    resources :admin_users
   end
 end

--- a/db/migrate/20231205083416_add_role_to_admins.rb
+++ b/db/migrate/20231205083416_add_role_to_admins.rb
@@ -1,0 +1,5 @@
+class AddRoleToAdmins < ActiveRecord::Migration[7.0]
+  def change
+    add_column :admins, :role, :integer, null: false,        comment: "管理者の役割"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_12_04_170103) do
+ActiveRecord::Schema[7.0].define(version: 2023_12_05_083416) do
   create_table "admins", charset: "utf8", force: :cascade do |t|
     t.string "email", default: "", null: false
     t.string "encrypted_password", default: "", null: false
@@ -20,6 +20,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_12_04_170103) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "name", default: "", null: false
+    t.integer "role", null: false, comment: "管理者の役割"
     t.index ["email"], name: "index_admins_on_email", unique: true
     t.index ["reset_password_token"], name: "index_admins_on_reset_password_token", unique: true
   end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -51,3 +51,10 @@ prefectures = [
 prefectures.each do |prefecture|
   Prefecture.create!(prefecture)
 end
+
+Admin.create!(
+  email: 'zig235@au.com',
+  password: 'zig235235',
+  name: '岩橋拓海',
+  role: Admin.role.admin.value
+)

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -56,5 +56,5 @@ Admin.create!(
   email: 'zig235@au.com',
   password: 'zig235235',
   name: '岩橋拓海',
-  role: Admin.role.admin.value
+  role: Admin.role.owner.value
 )


### PR DESCRIPTION
### 対応内容・対応背景

deviseでログイン機能を作成していたため、deviseの設定であるregisterableにより管理ユーザ新規作成画面を設定していたが、それでは誰でも管理ユーザーを作成できてしまったため、registerableを削除して、権限をadminモデルに追加し、ログイン権限がadminのユーザーのみが管理ユーザーを作成、編集できるように設定。
また、オーナーアカウントをseedsで作成し、オーナーアカウントの編集はオーナーアカウント以外できないように設定

### やったこと(管理ユーザー)

- 管理側の管理ユーザーの新規作成、一覧、詳細、編集、削除機能を作成
- deviseの設定を変更し、registerableモジュールを無効化し、管理側で管理ユーザーを作成するように設定
- 初期管理ユーザーとしてseedでオーナーアカウントを作成
- オーナーアカウントはオーナーアカウントのみしか編集できないように、controllerで認証情報を作成し、viewではif文を利用してリンクを表示せず、接続できないように設定
- Adminモデルにrole(権限)カラムを追加し、enumerizeでmemberとadminを列挙型で設定。
- 設定した権限により、controllerで認証情報を作成し、viewではif文を利用してリンクを表示せず、権限がmemberの管理ユーザーでは管理ユーザーの管理画面に接続できないように設定
- サイドバーに管理ユーザー管理機能のリンクを設置
- ヘッダーから不要になったアカウント編集画面などを削除し、名前と権限を表示するように変更
- 管理ユーザーの一覧画面で検索フォームを作成し名前であいまい検索できるように設定
- 管理ユーザーの一覧画面でセレクトボックスを作成し権限によりソートできるように設定
- ページネーションを作成。

### やったこと(ブログ管理)

- ブログ管理の一覧画面でセレクトボックスを作成しカテゴリーによりソートできるように設定


### やってないこと

- 公開側の画面の作成