### PR TITLE
管理側のレイアウトをsafari側でもエラーなく表示できるように設定

### DIFF
--- a/app/frontend/entrypoints/AdminApplication.tsx
+++ b/app/frontend/entrypoints/AdminApplication.tsx
@@ -11,7 +11,7 @@ const App: React.FC = (props: any) => {
   React.useEffect(() => {
     rewrap('articlecontents-component', ArticleContents, true);
   }, []);
-  const [isSidebarOpen, setIsSidebarOpen] = useState(true);
+  const [isSidebarOpen, setIsSidebarOpen] = useState(false);
   const toggleSidebar = React.useCallback(() => {
     if (isSidebarOpen) {
       setIsSidebarOpen(false);

--- a/app/frontend/entrypoints/AdminApplication.tsx
+++ b/app/frontend/entrypoints/AdminApplication.tsx
@@ -44,7 +44,7 @@ const App: React.FC = (props: any) => {
           newAdminsAdminUsersPath="/admins/admin_users/new"
           adminsAdminUsersPath="/admins/admin_users"
          ></Sidebar>
-        <main className={`${isSidebarOpen ? 'ml-sm-auto col-lg-10 col-md-9' : ''}  px-md-4 py-md-4 main-top`}>
+        <main className={`${isSidebarOpen ? 'ml-sm-auto col-lg-10 col-md-9' : ''}  p-md-4 p-3 main-top`}>
           {props.children}
         </main>
       </div>

--- a/app/frontend/entrypoints/admins.scss
+++ b/app/frontend/entrypoints/admins.scss
@@ -148,6 +148,12 @@
   }
 }
 
+@media (max-width: 1320px) {
+  .mobile-title {
+    margin-bottom: 1.5rem;
+  }
+}
+
 
 .article-wrap {
   padding: 0 80px;
@@ -377,10 +383,42 @@
   }
 }
 
-
 @media (max-width: 767px){
   .search-form-box {
     width: 100%;
   }
 }
 
+.job-entry-search-select {
+  margin-right: 1.5rem;
+}
+
+@media (max-width: 1085px){
+  .job-entry-search-select {
+    margin-bottom: 0.5rem;
+    margin-right: 1.5rem;
+  }
+}
+
+@media (max-width: 767px){
+  .job-entry-search-select {
+    margin-bottom: 0.5rem;
+    margin-right: 0;
+  }
+}
+
+.job-entry-search-form {
+  margin-right: 1.5rem;
+}
+
+@media (max-width: 1085px){
+  .job-entry-search-form {
+    margin-bottom: 0.5rem;
+  }
+}
+
+@media (max-width: 1024px){
+  .job-entry-search-form {
+    margin: 0;
+  }
+}

--- a/app/frontend/entrypoints/admins.scss
+++ b/app/frontend/entrypoints/admins.scss
@@ -3,7 +3,7 @@
 
 
 
-  @media (max-width: 320px) {
+  @media (max-width: 375px) {
     .list-inline-item:not(:last-child) {
       margin-bottom: 0.5rem;
     }
@@ -507,6 +507,47 @@
 
 @media (max-width: 576px){
   .article-search-form-box {
+    width: 100%;
+  }
+}
+
+
+.admin-user-search-select {
+  margin-right: 1.5rem;
+}
+
+@media (max-width: 1085px){
+  .admin-user-search-select {
+    margin-bottom: 0.5rem;
+    margin-right: 1.5rem;
+  }
+}
+
+@media (max-width: 430px){
+  .admin-user-search-select {
+    margin-bottom: 0.5rem;
+    margin-right: 0;
+  }
+}
+
+.admin-user-search-form {
+  margin: 0;
+}
+
+@media (max-width: 1085px){
+  .admin-user-search-form {
+    margin-bottom: 0.5rem;
+  }
+}
+
+@media (max-width: 576px){
+  .admin-user-search-form {
+    margin: 0;
+  }
+}
+
+@media (max-width: 430px){
+  .admin-user-search-form-box {
     width: 100%;
   }
 }

--- a/app/frontend/entrypoints/admins.scss
+++ b/app/frontend/entrypoints/admins.scss
@@ -142,6 +142,13 @@
   margin-bottom: 5rem;
 }
 
+@media (max-width: 767px) {
+  .mobile-title {
+    margin-bottom: 1rem;
+  }
+}
+
+
 .article-wrap {
   padding: 0 80px;
 }
@@ -335,3 +342,45 @@
     font-size: 14px;
   }
 }
+
+.contact-search-select {
+  margin-right: 1.5rem;
+}
+
+@media (max-width: 1085px){
+  .contact-search-select {
+    margin-bottom: 0.5rem;
+    margin-right: 1.5rem;
+  }
+}
+
+@media (max-width: 767px){
+  .contact-search-select {
+    margin-bottom: 0.5rem;
+    margin-right: 0;
+  }
+}
+
+.contact-search-form {
+  margin: 0;
+}
+
+@media (max-width: 1085px){
+  .contact-search-form {
+    margin-bottom: 0.5rem;
+  }
+}
+
+@media (max-width: 767px){
+  .contact-search-form {
+    margin: 0;
+  }
+}
+
+
+@media (max-width: 767px){
+  .search-form-box {
+    width: 100%;
+  }
+}
+

--- a/app/frontend/entrypoints/admins.scss
+++ b/app/frontend/entrypoints/admins.scss
@@ -1,6 +1,15 @@
 @use '@/stylesheets/application';
 @import 'main.scss';
 
+
+
+  @media (max-width: 320px) {
+    .list-inline-item:not(:last-child) {
+      margin-bottom: 0.5rem;
+    }
+  }
+  
+
 .admin-header {
   position: fixed;
   top: 0;
@@ -153,9 +162,6 @@
     margin-bottom: 1.5rem;
   }
 }
-
-
-
 
 .article-wrap {
   padding: 0 80px;
@@ -461,6 +467,46 @@
 
 @media (max-width: 576px){
   .news-search-form-box {
+    width: 100%;
+  }
+}
+
+.article-search-select {
+  margin-right: 1.5rem;
+}
+
+@media (max-width: 1085px){
+  .article-search-select {
+    margin-bottom: 0.5rem;
+    margin-right: 1.5rem;
+  }
+}
+
+@media (max-width: 576px){
+  .article-search-select {
+    margin-bottom: 0.5rem;
+    margin-right: 0;
+  }
+}
+
+.article-search-form {
+  margin: 0;
+}
+
+@media (max-width: 1085px){
+  .article-search-form {
+    margin-bottom: 0.5rem;
+  }
+}
+
+@media (max-width: 576px){
+  .article-search-form {
+    margin: 0;
+  }
+}
+
+@media (max-width: 576px){
+  .article-search-form-box {
     width: 100%;
   }
 }

--- a/app/frontend/entrypoints/admins.scss
+++ b/app/frontend/entrypoints/admins.scss
@@ -155,6 +155,8 @@
 }
 
 
+
+
 .article-wrap {
   padding: 0 80px;
 }
@@ -420,5 +422,45 @@
 @media (max-width: 1024px){
   .job-entry-search-form {
     margin: 0;
+  }
+}
+
+.news-search-select {
+  margin-right: 1.5rem;
+}
+
+@media (max-width: 1085px){
+  .news-search-select {
+    margin-bottom: 0.5rem;
+    margin-right: 1.5rem;
+  }
+}
+
+@media (max-width: 576px){
+  .news-search-select {
+    margin-bottom: 0.5rem;
+    margin-right: 0;
+  }
+}
+
+.news-search-form {
+  margin: 0;
+}
+
+@media (max-width: 1085px){
+  .news-search-form {
+    margin-bottom: 0.5rem;
+  }
+}
+
+@media (max-width: 576px){
+  .news-search-form {
+    margin: 0;
+  }
+}
+
+@media (max-width: 576px){
+  .news-search-form-box {
+    width: 100%;
   }
 }

--- a/app/frontend/entrypoints/main.scss
+++ b/app/frontend/entrypoints/main.scss
@@ -33,7 +33,7 @@ em {
   }
 }
 
-@media (max-width: 687px) {
+@media (max-width: 812px) {
   .mobile-shop-block {
     display: block !important;
   }

--- a/app/frontend/entrypoints/main.scss
+++ b/app/frontend/entrypoints/main.scss
@@ -117,3 +117,13 @@ em {
   }
 }
 
+@media (max-width: 576px) {
+  .mobile-article-full-width {
+    width: 100%;
+  }
+}
+@media (max-width: 616px) {
+  .mobile-article-btn-full-width {
+    width: 100%;
+  }
+}

--- a/app/frontend/entrypoints/main.scss
+++ b/app/frontend/entrypoints/main.scss
@@ -39,6 +39,12 @@ em {
   }
 }
 
+@media (max-width: 599px) {
+  .mobile-admin-users-block {
+    display: block !important;
+  }
+}
+
 @media (max-width: 576px) {
   .mobile-gutter {
     --bs-gutter-x: 0;
@@ -130,6 +136,17 @@ em {
 }
 @media (max-width: 616px) {
   .mobile-article-btn-full-width {
+    width: 100%;
+  }
+}
+
+@media (max-width: 430px) {
+  .mobile-admin-user-full-width {
+    width: 100%;
+  }
+}
+@media (max-width: 430px) {
+  .mobile-admin-user-btn-full-width {
     width: 100%;
   }
 }

--- a/app/frontend/entrypoints/main.scss
+++ b/app/frontend/entrypoints/main.scss
@@ -27,6 +27,12 @@ em {
   }
 }
 
+@media (max-width: 599px) {
+  .mobile-news-block {
+    display: block !important;
+  }
+}
+
 @media (max-width: 576px) {
   .mobile-gutter {
     --bs-gutter-x: 0;
@@ -93,8 +99,20 @@ em {
   }
 }
 
+@media (max-width: 576px) {
+  .mobile-news-full-width {
+    width: 100%;
+  }
+}
+
 @media (max-width: 1085px) {
   .mobile-btn-full-width {
+    width: 100%;
+  }
+}
+
+@media (max-width: 576px) {
+  .mobile-news-btn-full-width {
     width: 100%;
   }
 }

--- a/app/frontend/entrypoints/main.scss
+++ b/app/frontend/entrypoints/main.scss
@@ -21,7 +21,7 @@ em {
   justify-content: center;
 }
 
-@media (max-width: 576px) {
+@media (max-width: 1320px) {
   .mobile-block {
     display: block !important;
   }
@@ -84,6 +84,18 @@ em {
 @media (max-width: 576px) {
   .mobile-p-0 {
     padding: 0 !important;
+  }
+}
+
+@media (max-width: 1024px) {
+  .mobile-full-width {
+    width: 100%;
+  }
+}
+
+@media (max-width: 1085px) {
+  .mobile-btn-full-width {
+    width: 100%;
   }
 }
 

--- a/app/frontend/entrypoints/main.scss
+++ b/app/frontend/entrypoints/main.scss
@@ -33,6 +33,12 @@ em {
   }
 }
 
+@media (max-width: 687px) {
+  .mobile-shop-block {
+    display: block !important;
+  }
+}
+
 @media (max-width: 576px) {
   .mobile-gutter {
     --bs-gutter-x: 0;

--- a/app/views/admins/admin_users/index.html.erb
+++ b/app/views/admins/admin_users/index.html.erb
@@ -1,12 +1,14 @@
 <% breadcrumb :admins_admin_users %>
-<div class="d-flex justify-content-between mb-4 mobile-block">
-  <h3 class="fw-bold"><%= link_to '管理者一覧', admins_admin_users_path, class: 'text-dark text-decoration-none' %></h3>
+<div class="d-flex justify-content-between mb-4 mobile-admin-users-block">
+  <h3 class="fw-bold mobile-title"><%= link_to '管理者一覧', admins_admin_users_path, class: 'text-dark text-decoration-none' %></h3>
   <%= search_form_for @q, url: admins_admin_users_path, class: 'form-inline' do |f| %>
     <div class="input-group">
-      <%= f.select :search_by_role, Admin.role.options, { include_blank: '全ての権限' }, class: 'form-select-sm me-4' %>
-      <%= f.search_field :name_cont, class: 'form-control', placeholder: '名前で検索' %>
-      <div class="input-group-append">
-        <%= f.submit '検索', class: 'btn btn-primary' %>
+      <%= f.select :search_by_role, Admin.role.options, { include_blank: '全ての権限' }, class: 'form-select-sm admin-user-search-select admin-user-search-form-box' %>
+      <div class="mobile-admin-user-full-width admin-user-search-form">
+        <%= f.search_field :name_cont, class: 'form-control', placeholder: '名前で検索' %>
+      </div>
+      <div class="input-group-append mobile-admin-user-btn-full-width">
+        <%= f.submit '検索', class: 'btn btn-primary mobile-admin-user-btn-full-width' %>
       </div>
     </div>
   <% end %>

--- a/app/views/admins/articles/index.html.erb
+++ b/app/views/admins/articles/index.html.erb
@@ -1,13 +1,15 @@
 <% breadcrumb :admins_articles %>
 <div class="d-flex justify-content-between mb-4 mobile-block">
-  <h3 class="fw-bold"><%= link_to 'ブログ一覧', admins_articles_path, class: 'text-dark text-decoration-none' %></h3>
+  <h3 class="fw-bold mobile-title"><%= link_to 'ブログ一覧', admins_articles_path, class: 'text-dark text-decoration-none' %></h3>
   <%= search_form_for @q, url: admins_articles_path, class: 'form-inline' do |f| %>
     <div class="input-group">
-      <%= f.select :search_by_status, Article.status.options, { include_blank: '全ての公開状態' }, class: 'form-select-sm me-4' %>
-      <%= f.select :search_by_category, Article.category.options, { include_blank: '全てのカテゴリー' }, class: 'form-select-sm me-4' %>
-      <%= f.search_field :title_cont, class: 'form-control', placeholder: 'タイトルで検索' %>
-      <div class="input-group-append">
-        <%= f.submit '検索', class: 'btn btn-primary' %>
+      <%= f.select :search_by_status, Article.status.options, { include_blank: '全ての公開状態' }, class: 'form-select-sm article-search-select article-search-form-box' %>
+      <%= f.select :search_by_category, Article.category.options, { include_blank: '全てのカテゴリー' }, class: 'form-select-sm article-search-select article-search-form-box' %>
+      <div class="mobile-article-full-width article-search-form">
+        <%= f.search_field :title_cont, class: 'form-control', placeholder: 'タイトルで検索' %>
+      </div>
+      <div class="input-group-append mobile-article-btn-full-width">
+        <%= f.submit '検索', class: 'btn btn-primary mobile-article-btn-full-width' %>
       </div>
     </div>
   <% end %>

--- a/app/views/admins/contacts/index.html.erb
+++ b/app/views/admins/contacts/index.html.erb
@@ -1,14 +1,17 @@
 <% breadcrumb :admins_contacts %>
 <div class="d-flex justify-content-between mb-4 mobile-block">
-  <h3 class="fw-bold"><%= link_to '問い合わせ一覧', admins_contacts_path, class: 'text-dark text-decoration-none' %></h3>
+  <h3 class="fw-bold mobile-title"><%= link_to '問い合わせ一覧', admins_contacts_path, class: 'text-dark text-decoration-none' %></h3>
   <%= search_form_for @q, url: admins_contacts_path, class: 'form-inline' do |f| %>
     <div class="input-group">
-      <%= f.select :search_by_contact_type, Contact.contact_type.options, { include_blank: '全ての問い合わせタイプ' }, class: 'form-select-sm me-4' %>
-      <%= f.select :search_by_contact_method, Contact.contact_method.options, { include_blank: '全ての連絡方法' }, class: 'form-select-sm me-4' %>
-      <%= f.select :search_by_status, Contact.status.options, { include_blank: '全ての対応状況' }, class: 'form-select-sm me-4' %>
-      <%= f.search_field :name_cont, class: 'form-control', placeholder: '名前で検索' %>
-      <div class="input-group-append">
-        <%= f.submit '検索', class: 'btn btn-primary' %>
+      <%= f.select :search_by_contact_type, Contact.contact_type.options, { include_blank: '全ての問い合わせタイプ' }, class: 'form-select-sm contact-search-select search-form-box' %>
+      <%= f.select :search_by_contact_method, Contact.contact_method.options, { include_blank: '全ての連絡方法' }, class: 'form-select-sm contact-search-select search-form-box' %>
+      <%= f.select :search_by_status, Contact.status.options, { include_blank: '全ての対応状況' }, class: 'form-select-sm contact-search-select search-form-box' %>
+      <div class="mobile-full-width contact-search-form">
+        <%= f.search_field :name_cont, class: 'form-control', placeholder: '名前で検索' %>
+      </div>
+      <div class="input-group-append mobile-btn-full-width">
+        <%= f.submit '検索', class: 'btn btn-primary mobile-btn-full-width' %>
+      </div>
       </div>
     </div>
   <% end %>

--- a/app/views/admins/contacts/index.html.erb
+++ b/app/views/admins/contacts/index.html.erb
@@ -12,7 +12,6 @@
       <div class="input-group-append mobile-btn-full-width">
         <%= f.submit '検索', class: 'btn btn-primary mobile-btn-full-width' %>
       </div>
-      </div>
     </div>
   <% end %>
 </div>

--- a/app/views/admins/job_entries/index.html.erb
+++ b/app/views/admins/job_entries/index.html.erb
@@ -1,15 +1,19 @@
 <% breadcrumb :admins_job_entries %>
 <div class="d-flex justify-content-between mb-4 mobile-block">
-  <h3 class="fw-bold"><%= link_to '採用応募一覧', admins_job_entries_path, class: 'text-dark text-decoration-none' %></h3>
+  <h3 class="fw-bold mobile-title"><%= link_to '採用応募一覧', admins_job_entries_path, class: 'text-dark text-decoration-none' %></h3>
   <%= search_form_for @q, url: admins_job_entries_path, class: 'form-inline' do |f| %>
     <div class="input-group">
-      <%= f.select :search_by_recruit_type, JobEntry.recruit_type.options, { include_blank: '全ての採用タイプ' }, class: 'form-select-sm me-4' %>
-      <%= f.select :search_by_sex, JobEntry.sex.options, { include_blank: '全ての性別' }, class: 'form-select-sm me-4' %>
-      <%= f.select :search_by_status, JobEntry.status.options, { include_blank: '全ての対応状況' }, class: 'form-select-sm me-4' %>
-      <%= f.search_field :name_cont, class: 'form-control me-2', placeholder: '名前で検索' %>
-      <%= f.search_field @search_residence_scope, class: 'form-control', placeholder: '住所で検索' %>
-      <div class="input-group-append">
-        <%= f.submit '検索', class: 'btn btn-primary' %>
+      <%= f.select :search_by_recruit_type, JobEntry.recruit_type.options, { include_blank: '全ての採用タイプ' }, class: 'form-select-sm job-entry-search-select search-form-box' %>
+      <%= f.select :search_by_sex, JobEntry.sex.options, { include_blank: '全ての性別' }, class: 'form-select-sm job-entry-search-select search-form-box' %>
+      <%= f.select :search_by_status, JobEntry.status.options, { include_blank: '全ての対応状況' }, class: 'form-select-sm job-entry-search-select search-form-box' %>
+      <div class="mobile-full-width job-entry-search-form">
+        <%= f.search_field :name_cont, class: 'form-control', placeholder: '名前で検索' %>
+      </div>
+      <div class="mobile-full-width">
+        <%= f.search_field @search_residence_scope, class: 'form-control', placeholder: '住所で検索' %>
+      </div> 
+      <div class="input-group-append  mobile-btn-full-width">
+        <%= f.submit '検索', class: 'btn btn-primary  mobile-btn-full-width' %>
       </div>
     </div>
   <% end %>

--- a/app/views/admins/news/index.html.erb
+++ b/app/views/admins/news/index.html.erb
@@ -1,12 +1,14 @@
 <% breadcrumb :admins_news_index %>
-<div class="d-flex justify-content-between mb-4 mobile-block">
-  <h3 class="fw-bold"><%= link_to 'お知らせ一覧', admins_news_index_path, class: 'text-dark text-decoration-none' %></h3>
+<div class="d-flex justify-content-between mb-4 mobile-news-block">
+  <h3 class="fw-bold mobile-title"><%= link_to 'お知らせ一覧', admins_news_index_path, class: 'text-dark text-decoration-none' %></h3>
   <%= search_form_for @q, url: admins_news_index_path, class: 'form-inline' do |f| %>
     <div class="input-group">
-      <%= f.select :search_by_status, News.status.options, { include_blank: '全ての公開状態' }, class: 'form-select-sm me-4' %>
-      <%= f.search_field @search_scope, class: 'form-control', placeholder: 'タイトルや内容で検索' %>
-      <div class="input-group-append">
-        <%= f.submit '検索', class: 'btn btn-primary' %>
+      <%= f.select :search_by_status, News.status.options, { include_blank: '全ての公開状態' }, class: 'form-select-sm news-search-select news-search-form-box' %>
+      <div class="mobile-news-full-width news-search-form">
+        <%= f.search_field @search_scope, class: 'form-control', placeholder: 'タイトルや内容で検索' %>
+      </div>
+      <div class="input-group-append mobile-news-btn-full-width">
+        <%= f.submit '検索', class: 'btn btn-primary mobile-news-btn-full-width' %>
       </div>
     </div>
   <% end %>

--- a/app/views/admins/shops/discarded.html.erb
+++ b/app/views/admins/shops/discarded.html.erb
@@ -1,8 +1,8 @@
 <% breadcrumb :discarded_admins_shops %>
-<div class="d-flex justify-content-between mb-4 mobile-block">
-  <h3 class="fw-bold"><%= link_to '削除済み店舗一覧', discarded_admins_shops_path, class: 'text-dark text-decoration-none' %></h3>
+<div class="d-flex justify-content-between mb-4 mobile-shop-block">
+  <h3 class="fw-bold mobile-title"><%= link_to '削除済み店舗一覧', discarded_admins_shops_path, class: 'text-dark text-decoration-none' %></h3>
   <%= search_form_for @q, url: discarded_admins_shops_path, class: 'form-inline' do |f| %>
-    <div class="d-flex mobile-block">
+    <div class="d-flex mobile-shop-block">
       <div class="input-group">
         <%= f.search_field :name_cont, class: 'form-control', placeholder: '店舗名で検索' %>
         <div class="input-group-append">

--- a/app/views/admins/shops/index.html.erb
+++ b/app/views/admins/shops/index.html.erb
@@ -1,8 +1,8 @@
 <% breadcrumb :admins_shops %>
-<div class="d-flex justify-content-between mb-4 mobile-block">
-  <h3 class="fw-bold"><%= link_to '店舗一覧', admins_shops_path, class: 'text-dark text-decoration-none' %></h3>
+<div class="d-flex justify-content-between mb-4 mobile-shop-block">
+  <h3 class="fw-bold mobile-title"><%= link_to '店舗一覧', admins_shops_path, class: 'text-dark text-decoration-none' %></h3>
   <%= search_form_for @q, url: admins_shops_path, class: 'form-inline' do |f| %>
-    <div class="d-flex mobile-block">
+    <div class="d-flex  mobile-shop-block">
       <div class="input-group">
         <%= f.search_field :name_cont, class: 'form-control', placeholder: '店舗名で検索' %>
         <div class="input-group-append">

--- a/app/views/layouts/admins.html.erb
+++ b/app/views/layouts/admins.html.erb
@@ -25,7 +25,7 @@
   <% if admin_signed_in? %>
     <%= vite_javascript_tag 'AdminApplication.tsx' %>
     <app-component data-props="<%= { currentAdmin: current_admin.data_props }.to_json %>">
-      <div class="container mobile-gutter mobile-p-3">
+      <div class="mobile-gutter">
         <nav aria-label="breadcrumb">
           <ol class="breadcrumb" >
             <%= breadcrumbs separator: " &rsaquo; ", class: "custom-breadcrumb" %>


### PR DESCRIPTION
### 背景
管理側を作成した際はgoogle chromeでスマホサイズなどを確認していたが公開側を作成していく過程でsafariを利用する際とレイアウトが異なることがわかり、スマホユーザーの多くはsafariを利用するため、そちらでもレイアウトが崩れないように設定

### やったこと

- 各管理側に一覧画面をsafariの画面でもレイアウトが崩れず表示される様に設定
- 管理側のレイアウトの大枠を変更